### PR TITLE
Add a list of ignored domains

### DIFF
--- a/site/src/analytics-integrations.ts
+++ b/site/src/analytics-integrations.ts
@@ -34,6 +34,7 @@ const IGNORED_DOMAINS = [
   "person",
   "search",
   "system_log",
+  "trace",
   "websocket_api",
 ];
 

--- a/site/src/analytics-integrations.ts
+++ b/site/src/analytics-integrations.ts
@@ -20,6 +20,23 @@ import {
 
 const isMobile = matchMedia("(max-width: 600px)").matches;
 
+const IGNORED_DOMAINS = [
+  "api",
+  "auth",
+  "analytics",
+  "config",
+  "device_automation",
+  "frontend",
+  "image",
+  "http",
+  "lovelace",
+  "onboarding",
+  "person",
+  "search",
+  "system_log",
+  "websocket_api",
+];
+
 @customElement("analytics-integrations")
 export class AnalyticsIntegrations extends LitElement {
   @property({ attribute: false }) public data?: AnalyticsData;
@@ -185,13 +202,15 @@ export class AnalyticsIntegrations extends LitElement {
         )
       );
 
-      this._integrations = Array.from(domains).map((domain) => {
-        return {
-          domain,
-          title: this._integrationDetails[domain]?.title || domain,
-          installations: lastEntry.integrations[domain] || 0,
-        };
-      });
+      this._integrations = Array.from(domains)
+        .filter((domain) => !IGNORED_DOMAINS.includes(domain))
+        .map((domain) => {
+          return {
+            domain,
+            title: this._integrationDetails[domain]?.title || domain,
+            installations: lastEntry.integrations[domain] || 0,
+          };
+        });
     } catch (err) {
       console.log(err);
     }

--- a/site/src/analytics-integrations.ts
+++ b/site/src/analytics-integrations.ts
@@ -21,14 +21,14 @@ import {
 const isMobile = matchMedia("(max-width: 600px)").matches;
 
 const IGNORED_DOMAINS = [
+  "analytics",
   "api",
   "auth",
-  "analytics",
   "config",
   "device_automation",
   "frontend",
-  "image",
   "http",
+  "image",
   "lovelace",
   "onboarding",
   "person",


### PR DESCRIPTION
Add a list of ignored domains to hide from the integrations table.
As a start, the  "frontend" integration and all it's dependencies (and sub-deps) are added 
<https://github.com/home-assistant/core/blob/dev/homeassistant/components/frontend/manifest.json>