### PR TITLE
Round integration percentage to 1 decimal

### DIFF
--- a/site/src/analytics-integrations.ts
+++ b/site/src/analytics-integrations.ts
@@ -136,7 +136,7 @@ export class AnalyticsIntegrations extends LitElement {
               </td>
               <td class="installations">
                 ${entry.installations}
-                (${(
+                (${+(
                   (100 * entry.installations) /
                   this.lastDataEntry!.reports_integrations
                 ).toFixed(1)}%)

--- a/site/src/analytics-integrations.ts
+++ b/site/src/analytics-integrations.ts
@@ -136,10 +136,10 @@ export class AnalyticsIntegrations extends LitElement {
               </td>
               <td class="installations">
                 ${entry.installations}
-                (${Math.round(
+                (${(
                   (100 * entry.installations) /
-                    this.lastDataEntry!.reports_integrations
-                )}%)
+                  this.lastDataEntry!.reports_integrations
+                ).toFixed(1)}%)
               </td>
             </tr>
           `


### PR DESCRIPTION
Integration percentage rounded to 1 decimal looks better than just 0% and percentage of instalations is also rounded to 1 decimal.