### PR TITLE
Store a copy of the integration details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 worker/worker
 site/public/data.json
+site/public/integration_details.json

--- a/script/build
+++ b/script/build
@@ -18,6 +18,8 @@ else
   curl -sSLf https://analytics.home-assistant.io/data.json | jq . > ./site/public/data.json
 fi
 
+curl -sSLf https://www.home-assistant.io/integrations.json | jq . > ./site/public/integration_details.json
+
 
 if [ ! -d node_modules ]; then
   script/bootstrap

--- a/script/develop
+++ b/script/develop
@@ -7,6 +7,7 @@ set -e
 cd "$(dirname "$0")/.."
 
 curl -sSLf https://analytics.home-assistant.io/data.json | jq . > ./site/public/data.json
+curl -sSLf https://www.home-assistant.io/integrations.json | jq . > ./site/public/integration_details.json
 
 if [ ! -d node_modules ]; then
   script/bootstrap

--- a/site/src/data.ts
+++ b/site/src/data.ts
@@ -45,8 +45,7 @@ export const AnalyticsPages = ["installations", "statistics", "integrations"];
 
 export const fetchData = () => fetch("/data.json");
 
-export const fetchIntegrationDetails = () =>
-  fetch("https://www.home-assistant.io/integrations.json");
+export const fetchIntegrationDetails = () => fetch("/integration_details.json");
 
 export const relativeTime = (targetTimestamp: number): string => {
   const now = new Date();


### PR DESCRIPTION
Limit request to the doc site by storing a copy of `integrations.json` on build