### PR TITLE
Remove header rule

### DIFF
--- a/script/build
+++ b/script/build
@@ -6,6 +6,8 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+mkdir -p ./site/public
+
 if [ -n "$CF_KV_TOKEN" ]; then
   if [ -n "$INCOMING_HOOK_URL" ]; then
     sleep 61 # Wait for KV writes to reach all nodes

--- a/script/develop
+++ b/script/develop
@@ -6,6 +6,8 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+mkdir -p ./site/public
+
 curl -sSLf https://analytics.home-assistant.io/data.json | jq . > ./site/public/data.json
 curl -sSLf https://www.home-assistant.io/integrations.json | jq . > ./site/public/integration_details.json
 

--- a/site/public/_headers
+++ b/site/public/_headers
@@ -1,2 +1,0 @@
-/data.json
-  Access-Control-Allow-Origin: *


### PR DESCRIPTION
Since we are downloading this on build, this rule is no longer needed.