### PR TITLE
Showing average users number with two decimal places

### DIFF
--- a/site/src/analytics-average.ts
+++ b/site/src/analytics-average.ts
@@ -32,7 +32,7 @@ export class AnalyticsAverage extends LitElement {
         </div>
         <div class="metric">
           <span>Average users</span>
-          <span .title=${users}>${Math.round(Number(users))}</span>
+          <span .title=${users}>${Number(users)}</span>
         </div>
       </div>
       <div class="footer">


### PR DESCRIPTION
This it what we can see on the page https://analytics.home-assistant.io/#statistics :

![Screen Shot 2021-04-19 at 17 29 51](https://user-images.githubusercontent.com/47263/115253294-e9ee1e00-a134-11eb-911d-8adf1a04e852.png)

It is not clear what does this number mean. It is 1.6 users or 2.9 ?

In this PR I've changed the way that number is shown:

![Screen Shot 2021-04-19 at 17 31 17](https://user-images.githubusercontent.com/47263/115253454-1013be00-a135-11eb-9493-76cf00c22161.png)

Now it is clear how many users are there on average.

On that page there are several more numbers:

 * Average integrations — 76
 * Average entities — 287
 * Average automations — 33

But that numbers are pretty big, so I don't feel that there should be a fractional part for them. That's why I've left them untouched.
