### PR TITLE
Fix build script

### DIFF
--- a/script/build
+++ b/script/build
@@ -57,7 +57,7 @@ fi
 
 # Export to files
 echo "$addons" | jq . > "$addons_path"
-echo "$custom_integrations" > "$custom_integrations_path"
+echo "$custom_integrations" | jq . > "$custom_integrations_path"
 echo "$data" | jq . > "$data_path"
 echo "$integration_details" | jq . > "$integration_details_path"
 


### PR DESCRIPTION
Currently, the build script fails when CF_KV_TOKEN is not present due to quotations 