### PR TITLE
Fix filewatcher with WSL

### DIFF
--- a/site/vite.config.js
+++ b/site/vite.config.js
@@ -1,8 +1,11 @@
 const fs = require("fs");
-const isWsl = fs
-  .readFileSync("/proc/version", "utf-8")
-  .toLocaleLowerCase()
-  .includes("microsoft");
+
+const isWsl =
+  fs.existsSync("/proc/version") &&
+  fs
+    .readFileSync("/proc/version", "utf-8")
+    .toLocaleLowerCase()
+    .includes("microsoft");
 
 export default {
   server: {

--- a/site/vite.config.js
+++ b/site/vite.config.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const isWsl = fs.readFileSync("/proc/version", "utf-8").toLocaleLowerCase().includes("microsoft")
+
+export default {
+  server: {
+    watch: isWsl ? { usePolling: true} : undefined
+  }
+}

--- a/site/vite.config.js
+++ b/site/vite.config.js
@@ -1,8 +1,11 @@
-const fs = require('fs');
-const isWsl = fs.readFileSync("/proc/version", "utf-8").toLocaleLowerCase().includes("microsoft")
+const fs = require("fs");
+const isWsl = fs
+  .readFileSync("/proc/version", "utf-8")
+  .toLocaleLowerCase()
+  .includes("microsoft");
 
 export default {
   server: {
-    watch: isWsl ? { usePolling: true} : undefined
-  }
-}
+    watch: { usePolling: isWsl },
+  },
+};


### PR DESCRIPTION
File watcher is unstable at best under WSL.
Setting `usePolling` to `true` when we detect that it's running under WSL makes it so you don't have to restart the develop script after each change