### PR TITLE
Add grouped version data to history

### DIFF
--- a/worker/src/data.ts
+++ b/worker/src/data.ts
@@ -118,6 +118,7 @@ export interface AnalyticsDataHistory {
     supervised: number;
     unknown: number;
   };
+  versions?: Record<string, number>;
 }
 
 export interface AnalyticsDataCurrent {

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -26,6 +26,7 @@ import {
   VERSION_URL,
 } from "../data";
 import { average } from "../utils/average";
+import { groupVersions } from "../utils/group-versions";
 import { migrateAnalyticsData } from "../utils/migrate";
 
 export async function handleSchedule(
@@ -124,6 +125,7 @@ async function updateHistory(sentry: Toucan): Promise<void> {
     data.installation_types.os +
     data.installation_types.supervised +
     data.installation_types.unknown;
+  const grouped_versions = groupVersions(data.versions);
 
   analyticsData.current.installation_types = data.installation_types;
   analyticsData.current.active_installations = active_installations;
@@ -133,6 +135,7 @@ async function updateHistory(sentry: Toucan): Promise<void> {
     timestamp: timestampString,
     active_installations,
     installation_types: data.installation_types,
+    versions: grouped_versions,
   });
 
   sentry.addBreadcrumb({ message: "Trigger Netlify build" });

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -125,7 +125,6 @@ async function updateHistory(sentry: Toucan): Promise<void> {
     data.installation_types.os +
     data.installation_types.supervised +
     data.installation_types.unknown;
-  const grouped_versions = groupVersions(data.versions);
 
   analyticsData.current.installation_types = data.installation_types;
   analyticsData.current.active_installations = active_installations;
@@ -135,7 +134,7 @@ async function updateHistory(sentry: Toucan): Promise<void> {
     timestamp: timestampString,
     active_installations,
     installation_types: data.installation_types,
-    versions: grouped_versions,
+    versions: groupVersions(data.versions),
   });
 
   sentry.addBreadcrumb({ message: "Trigger Netlify build" });

--- a/worker/src/utils/group-versions.ts
+++ b/worker/src/utils/group-versions.ts
@@ -1,0 +1,17 @@
+export const groupVersions = (versions: Record<string, number>) => {
+  const releases: Record<string, number> = {};
+  const releases_filtered: Record<string, number> = {};
+
+  Object.keys(versions).forEach((version) => {
+    const key: string = version.split(".").slice(0, 2).join(".");
+    releases[key] = (releases[key] || 0) + versions[version];
+  });
+
+  Object.keys(releases)
+    .filter((key) => releases[key] > 100)
+    .forEach((key) => {
+      releases_filtered[key] = releases[key];
+    });
+
+  return releases_filtered;
+}

--- a/worker/tests/utils/group-versions.spec.ts
+++ b/worker/tests/utils/group-versions.spec.ts
@@ -1,0 +1,24 @@
+import { groupVersions } from "../../src/utils/group-versions"
+
+it("test", function () {
+  const data = {
+    "1970.1.0": 11,
+    "2021.4.0": 60,
+    "2021.4.1": 30,
+    "2021.4.2": 20,
+    "2021.5.0b0": 100,
+    "2021.5.0": 20,
+    "2021.5.5": 30,
+    "2021.6.0.dev20210517": 8,
+    "2021.6.0.dev20210506": 11,
+    "2021.6.0": 100,
+    "2021.7.0.dev20210601": 7,
+  };
+  const versions = {
+    "2021.4": 110,
+    "2021.5": 150,
+    "2021.6": 119,
+  };
+
+  expect(groupVersions(data)).toStrictEqual(versions);
+});


### PR DESCRIPTION
At the moment, we don't store any history information for `versions`. That is unfortunate as it prevents us from showing any time based changes aside from the current distribution.

With this PR a grouped version count will be added to each new history entry. The algorithm is the one currently used to display the `Last releases` chart.

This will enable us to show a graph of the version history similar to the one for `Active Installations` => #219