### PR TITLE
Version history - reverse ordering to match `Last releases`

### DIFF
--- a/site/src/analytics-version-history.ts
+++ b/site/src/analytics-version-history.ts
@@ -41,11 +41,11 @@ export class AnalyticsVersionHistory extends LitElement {
     const versionsOrdered: string[] = Array.from(allVersions)
       .sort((a, b) => {
         const mainVersionCmp =
-          parseInt(a.split(".")[0]) - parseInt(b.split(".")[0]);
+          parseInt(b.split(".")[0]) - parseInt(a.split(".")[0]);
         if (mainVersionCmp !== 0) {
           return mainVersionCmp;
         }
-        return parseInt(a.split(".")[1]) - parseInt(b.split(".")[1]);
+        return parseInt(b.split(".")[1]) - parseInt(a.split(".")[1]);
       });
 
     const rows = versionHistoryData


### PR DESCRIPTION
Currently `Last releases` uses descending ordering whereas the `Version history` uses ascending ordering. The result is that the colors between the pi chart and the graph don't match up.

This PR reverses the ordering for the `Version history`.