### PR TITLE
Bump @material/mwc-* from 0.25.1 to 0.25.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "dependencies": {
     "@google-web-components/google-chart": "^4.0.2",
-    "@material/mwc-checkbox": "^0.25.1",
-    "@material/mwc-formfield": "^0.25.1",
-    "@material/mwc-icon": "^0.25.1",
-    "@material/mwc-icon-button": "^0.25.1",
-    "@material/mwc-list": "^0.25.1",
-    "@material/mwc-select": "^0.25.1",
-    "@material/mwc-textfield": "^0.25.1",
+    "@material/mwc-checkbox": "^0.25.2",
+    "@material/mwc-formfield": "^0.25.2",
+    "@material/mwc-icon": "^0.25.2",
+    "@material/mwc-icon-button": "^0.25.2",
+    "@material/mwc-list": "^0.25.2",
+    "@material/mwc-select": "^0.25.2",
+    "@material/mwc-textfield": "^0.25.2",
     "@mdi/font": "^6.2.95",
     "@mdi/js": "^6.2.95",
     "lit": "^2.0.2",
@@ -34,6 +34,9 @@
     },
     "testEnvironment": "node",
     "testRegex": "/worker/tests/.*\\.spec\\.ts$",
-    "moduleFileExtensions": ["js", "ts"]
+    "moduleFileExtensions": [
+      "js",
+      "ts"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -529,437 +529,427 @@
   resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.0.0.tgz#7b6e6a85709cda0370c47e425ac2f3b553696a4b"
   integrity sha512-Kpgenb8UNFsKCsFhggiVvUkCbcFQSd6N8hffYEEGjz27/4rw3cTSsmP9t3q1EHOAsdum60Wo64HvuZDFpEwexA==
 
-"@material/animation@13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-13.0.0-canary.65125b3a6.0.tgz#ce5a8b0b4cd2e087694c656d59be22c80ef92d5d"
-  integrity sha512-MIBRoHQnzGyFXOf/txHfR5wH75kQqsymYTQCM50GeNBIVUqBYWhr6Nnu5ow47mykq1PwqRHSat0ohfSw+ILskQ==
+"@material/animation@14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-14.0.0-canary.353ca7e9f.0.tgz#7f63ff2a8f792a65e21470e6aa0ebb9f17f17f2c"
+  integrity sha512-r2H1k9iSLw/gR16TFAL8rCcr13unLyLVhI79FV39D2w6FvjXIH4XUqCOwHjUxDkO7NiHuB4TBCC5trgGVmwrXg==
   dependencies:
     tslib "^2.1.0"
 
-"@material/base@13.0.0-canary.65125b3a6.0", "@material/base@=13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/base/-/base-13.0.0-canary.65125b3a6.0.tgz#4e162682584223f1af28e381e80b0f8ea699300f"
-  integrity sha512-eN3zaT/zvQLWK0qmTIksXlJJnN4pT2ykZYPCipgKJK0cFAbU0F32rmgg3Z0cY0gUHEdI59hl2N20EKUFyQ4GHQ==
+"@material/base@14.0.0-canary.353ca7e9f.0", "@material/base@=14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/base/-/base-14.0.0-canary.353ca7e9f.0.tgz#802072bd01b8acdd7fc438ccf89d63208e1cb28d"
+  integrity sha512-Qg2H+G+QmJ5eXLaMDU5E6r3gHchRFmVxeYcgjPJ9LOGoneYELjahLFFdjMTkktCRF6vhIgP2dZ0YBejtMNpo3w==
   dependencies:
     tslib "^2.1.0"
 
-"@material/density@13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/density/-/density-13.0.0-canary.65125b3a6.0.tgz#9461a3438352a8dc872d0005fdb379997310a8af"
-  integrity sha512-W8Y2zJ/tjXPEl0JHWFxSpUNBqd6zUitzGXoR9I4yfjNY7t5TBkBNbexyPqtz3TWdLqM1xJrIdczDHsFKXLVN+w==
+"@material/density@14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/density/-/density-14.0.0-canary.353ca7e9f.0.tgz#c198623aafb82fcb3bbe92ae69967b57cebc4d57"
+  integrity sha512-sDDryeQXz8vQ5Uv6Q++tPJ6/Sw8TzY3sT1oLq4jRJHlshJKrqbmAycyRcTEx6vSW2AmBMse2RdPvFgcd5j8Ccg==
   dependencies:
     tslib "^2.1.0"
 
-"@material/dom@13.0.0-canary.65125b3a6.0", "@material/dom@=13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/dom/-/dom-13.0.0-canary.65125b3a6.0.tgz#846e6bf0c7a23fe265afc70680fec7f169de7e89"
-  integrity sha512-oqyruf8uAUIru2IIRIDpjzvjc29SzN+frYLhR1+CP0oDtG/yhuwPHqM8j4lLtPhwJPPZ127EHpb4lRqcM87nQw==
+"@material/dom@14.0.0-canary.353ca7e9f.0", "@material/dom@=14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/dom/-/dom-14.0.0-canary.353ca7e9f.0.tgz#9af140637f59e3cc62abb42867e60375b6812f72"
+  integrity sha512-nKETPNDJ3rR8T6KoLzTLiyuBctYBk5YuVSWlfrdA6GQnJR50GplUcaD0BYycpYfoYlIDh0lsfSjuTt2hpoBu8w==
   dependencies:
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/elevation@13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/elevation/-/elevation-13.0.0-canary.65125b3a6.0.tgz#bdbebd077eac92ccd20977004e159481a1acfa97"
-  integrity sha512-7FQGmQkDS4AiNWyxZRs3g+2HONnAAzhMNs51an7ifB2nZYvy8Llo9cIWfrsGXaZIYEG+Ef4/fCiIDjAUbUpiPw==
+"@material/elevation@14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/elevation/-/elevation-14.0.0-canary.353ca7e9f.0.tgz#4949e539a41ca8b3393a4df7018a7d7d74203448"
+  integrity sha512-IXD0Rn+Dx8DnrNTr2RGnSenoYaeUNQHuKnX7AsLc8zriBqb3FxfBfw10STke6J+hvXiKift8pTNlMEqGsod3kw==
   dependencies:
-    "@material/animation" "13.0.0-canary.65125b3a6.0"
-    "@material/base" "13.0.0-canary.65125b3a6.0"
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
-    "@material/rtl" "13.0.0-canary.65125b3a6.0"
-    "@material/theme" "13.0.0-canary.65125b3a6.0"
+    "@material/animation" "14.0.0-canary.353ca7e9f.0"
+    "@material/base" "14.0.0-canary.353ca7e9f.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
+    "@material/rtl" "14.0.0-canary.353ca7e9f.0"
+    "@material/theme" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/feature-targeting@13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/feature-targeting/-/feature-targeting-13.0.0-canary.65125b3a6.0.tgz#21373ee955b7d1d434ea05c7bbd54f623d7ebb5e"
-  integrity sha512-YFY/9zsUAycYHY6bw747/yVDvAshcIBDK6Z2B2VaSuu55+LCelHJOVwMsYQv1ADw3wQuEdno7HXphNds8w/Naw==
+"@material/feature-targeting@14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/feature-targeting/-/feature-targeting-14.0.0-canary.353ca7e9f.0.tgz#0e1616c3a07b10f63a8040878c1ab3f1de91fccb"
+  integrity sha512-JhFsnWvNwdGfbNGC1F3+QlYKWpAFfRkPhtuOjrs9G1DRZWj2zIy7ZuJTvtefK4VntDY+8vDFVwm8sV+9bn8eow==
   dependencies:
     tslib "^2.1.0"
 
-"@material/floating-label@13.0.0-canary.65125b3a6.0", "@material/floating-label@=13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/floating-label/-/floating-label-13.0.0-canary.65125b3a6.0.tgz#f40608cc51c328985869df69476a3b8eedb552ab"
-  integrity sha512-HFlV/dnEa2uHcA1tdW6ng8IczhLwHsg86kmfZ1221OMj8CbOhN5PZCPbLvm2xFZORPORYHnRj6tbFeRS2khRlw==
+"@material/floating-label@14.0.0-canary.353ca7e9f.0", "@material/floating-label@=14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/floating-label/-/floating-label-14.0.0-canary.353ca7e9f.0.tgz#557393c0789bffd8e68cc1335f5985e76e5edccf"
+  integrity sha512-PC/eLVRjTra4mv45I23Pg87m6sBYDkpZqbQQvmN++nV2oFArTtATOROkPgWrcuOuBX7CzdLlPSLop5PHFKan5g==
   dependencies:
-    "@material/animation" "13.0.0-canary.65125b3a6.0"
-    "@material/base" "13.0.0-canary.65125b3a6.0"
-    "@material/dom" "13.0.0-canary.65125b3a6.0"
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
-    "@material/rtl" "13.0.0-canary.65125b3a6.0"
-    "@material/theme" "13.0.0-canary.65125b3a6.0"
-    "@material/typography" "13.0.0-canary.65125b3a6.0"
+    "@material/animation" "14.0.0-canary.353ca7e9f.0"
+    "@material/base" "14.0.0-canary.353ca7e9f.0"
+    "@material/dom" "14.0.0-canary.353ca7e9f.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
+    "@material/rtl" "14.0.0-canary.353ca7e9f.0"
+    "@material/theme" "14.0.0-canary.353ca7e9f.0"
+    "@material/typography" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/form-field@=13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/form-field/-/form-field-13.0.0-canary.65125b3a6.0.tgz#7011375390ec9467477c45f4ed74b54d74888b7c"
-  integrity sha512-Y41jeBsQqploivo81ubcI3jJFx5C+r58JT6KMt5c2IqUluW/4ABMd8txgO7J93M4scdILY4FwaChDKf8UGq90A==
+"@material/form-field@=14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/form-field/-/form-field-14.0.0-canary.353ca7e9f.0.tgz#0c093252e86eea94072ef5192fe24df75e7efd37"
+  integrity sha512-dZWG07ulb98sjSlsTWUIBzcAyzXUw0xQ90QxKgxhTjHmOVmfHqocMsN/bbl4+1w4D1aT4LHc5Uob/YkRClSUWQ==
   dependencies:
-    "@material/base" "13.0.0-canary.65125b3a6.0"
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
-    "@material/ripple" "13.0.0-canary.65125b3a6.0"
-    "@material/rtl" "13.0.0-canary.65125b3a6.0"
-    "@material/theme" "13.0.0-canary.65125b3a6.0"
-    "@material/typography" "13.0.0-canary.65125b3a6.0"
+    "@material/base" "14.0.0-canary.353ca7e9f.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
+    "@material/ripple" "14.0.0-canary.353ca7e9f.0"
+    "@material/rtl" "14.0.0-canary.353ca7e9f.0"
+    "@material/theme" "14.0.0-canary.353ca7e9f.0"
+    "@material/typography" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/line-ripple@13.0.0-canary.65125b3a6.0", "@material/line-ripple@=13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/line-ripple/-/line-ripple-13.0.0-canary.65125b3a6.0.tgz#64f68d8f8c25326f12845e99995b2be10a76be37"
-  integrity sha512-7nz48IqqT5ZY04WDDTz9bmzd6b6Rg0ox1GxG+OzMOp5J5R40idhUpeg8ANm8QuFj8rzi4PfL8K+tvJqH0/oFWw==
+"@material/line-ripple@14.0.0-canary.353ca7e9f.0", "@material/line-ripple@=14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/line-ripple/-/line-ripple-14.0.0-canary.353ca7e9f.0.tgz#a866216b586504a6362d8b9fedff3a973e80b6ea"
+  integrity sha512-wIqJQkdhnPySy76o7khss6iRth8B4kxNQOXvZ1CX9liCGTf4z/ZbMbG9wJeF6VPZerJvyy22oNKmzOQOFzEaTg==
   dependencies:
-    "@material/animation" "13.0.0-canary.65125b3a6.0"
-    "@material/base" "13.0.0-canary.65125b3a6.0"
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
-    "@material/theme" "13.0.0-canary.65125b3a6.0"
+    "@material/animation" "14.0.0-canary.353ca7e9f.0"
+    "@material/base" "14.0.0-canary.353ca7e9f.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
+    "@material/theme" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/list@13.0.0-canary.65125b3a6.0", "@material/list@=13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/list/-/list-13.0.0-canary.65125b3a6.0.tgz#ec768b3f6554a0eea77afe6d64a399451b1cedcb"
-  integrity sha512-oKfE+e2uIeXT68YPIjkjo1JM4VYThUVJhzSWj6MSFzLcqA0I55IOkh7NBUGcmhEiNs1yd1lGeDACOhJpr2RBNg==
+"@material/list@14.0.0-canary.353ca7e9f.0", "@material/list@=14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/list/-/list-14.0.0-canary.353ca7e9f.0.tgz#ead26fce9e5c85ff021fb7a5126015b90b874787"
+  integrity sha512-yR50e7YbVMdxukkOBVwQr07il9DON55J0Too7cH9d0mGLH81RLrf/+NVdCQUaPA0OS6gyyDyQUgUpPrOfGc8Zw==
   dependencies:
-    "@material/base" "13.0.0-canary.65125b3a6.0"
-    "@material/density" "13.0.0-canary.65125b3a6.0"
-    "@material/dom" "13.0.0-canary.65125b3a6.0"
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
-    "@material/ripple" "13.0.0-canary.65125b3a6.0"
-    "@material/rtl" "13.0.0-canary.65125b3a6.0"
-    "@material/shape" "13.0.0-canary.65125b3a6.0"
-    "@material/theme" "13.0.0-canary.65125b3a6.0"
-    "@material/typography" "13.0.0-canary.65125b3a6.0"
+    "@material/base" "14.0.0-canary.353ca7e9f.0"
+    "@material/density" "14.0.0-canary.353ca7e9f.0"
+    "@material/dom" "14.0.0-canary.353ca7e9f.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
+    "@material/ripple" "14.0.0-canary.353ca7e9f.0"
+    "@material/rtl" "14.0.0-canary.353ca7e9f.0"
+    "@material/shape" "14.0.0-canary.353ca7e9f.0"
+    "@material/theme" "14.0.0-canary.353ca7e9f.0"
+    "@material/typography" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/menu-surface@13.0.0-canary.65125b3a6.0", "@material/menu-surface@=13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/menu-surface/-/menu-surface-13.0.0-canary.65125b3a6.0.tgz#41ab6037132028f78387e9d9d23deaac1d06ff40"
-  integrity sha512-EDE5dz+BpT3DC846XipwbTG4Jpzyvyt3dV5fo9Vt6Akh7PQ7QB0IkyCkv5iPQ9l1rQ0L55TGtxRpT/uabmb2xg==
+"@material/menu-surface@14.0.0-canary.353ca7e9f.0", "@material/menu-surface@=14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/menu-surface/-/menu-surface-14.0.0-canary.353ca7e9f.0.tgz#25ad9aca5b7b352d614fa87b0443a71f77d3ea42"
+  integrity sha512-iTdbxE+0a/SaUanaAvafAoXEsfDK6jrD94U8sXfXfPm7xKVy4Bzty1pGLLl2c5aszv5rI0uT0jgVVOUhUrYhag==
   dependencies:
-    "@material/animation" "13.0.0-canary.65125b3a6.0"
-    "@material/base" "13.0.0-canary.65125b3a6.0"
-    "@material/elevation" "13.0.0-canary.65125b3a6.0"
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
-    "@material/rtl" "13.0.0-canary.65125b3a6.0"
-    "@material/shape" "13.0.0-canary.65125b3a6.0"
-    "@material/theme" "13.0.0-canary.65125b3a6.0"
+    "@material/animation" "14.0.0-canary.353ca7e9f.0"
+    "@material/base" "14.0.0-canary.353ca7e9f.0"
+    "@material/elevation" "14.0.0-canary.353ca7e9f.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
+    "@material/rtl" "14.0.0-canary.353ca7e9f.0"
+    "@material/shape" "14.0.0-canary.353ca7e9f.0"
+    "@material/theme" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/menu@13.0.0-canary.65125b3a6.0", "@material/menu@=13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/menu/-/menu-13.0.0-canary.65125b3a6.0.tgz#42afb5cd85ff84e412a0551a01ba5dbbb12900e0"
-  integrity sha512-UW0f5Rl5r/V836bh23UO3k4nlePKlZkeAEvFr433lN0xcJqfpM/vJ46Yo5dxNS01YX2rgdaTg6FD1ayrt6jPJA==
+"@material/menu@14.0.0-canary.353ca7e9f.0", "@material/menu@=14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/menu/-/menu-14.0.0-canary.353ca7e9f.0.tgz#0a00d00a68f7a23b6184b2a5c3466a550ecb16ca"
+  integrity sha512-A+uAEQcXRjdZllcq0giQJoPgJUenh75igBIiwUCjgtWEZKUwND1/bqzS1HBe8qIQHRPfgMTSGS2W3KeJYDaLRA==
   dependencies:
-    "@material/base" "13.0.0-canary.65125b3a6.0"
-    "@material/dom" "13.0.0-canary.65125b3a6.0"
-    "@material/elevation" "13.0.0-canary.65125b3a6.0"
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
-    "@material/list" "13.0.0-canary.65125b3a6.0"
-    "@material/menu-surface" "13.0.0-canary.65125b3a6.0"
-    "@material/ripple" "13.0.0-canary.65125b3a6.0"
-    "@material/rtl" "13.0.0-canary.65125b3a6.0"
-    "@material/theme" "13.0.0-canary.65125b3a6.0"
+    "@material/base" "14.0.0-canary.353ca7e9f.0"
+    "@material/dom" "14.0.0-canary.353ca7e9f.0"
+    "@material/elevation" "14.0.0-canary.353ca7e9f.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
+    "@material/list" "14.0.0-canary.353ca7e9f.0"
+    "@material/menu-surface" "14.0.0-canary.353ca7e9f.0"
+    "@material/ripple" "14.0.0-canary.353ca7e9f.0"
+    "@material/rtl" "14.0.0-canary.353ca7e9f.0"
+    "@material/theme" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/mwc-base@^0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-base/-/mwc-base-0.25.1.tgz#7664bfa582e5a96f9bf1db65044d5402afdad68a"
-  integrity sha512-14E86cxBFlogWN0pJnyytsHOnH+gYCZvSWibT0rVRZVetIgOySqUsv60FH1chacRlTrspBZyzrfIUmpy7wTKew==
+"@material/mwc-base@^0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@material/mwc-base/-/mwc-base-0.25.2.tgz#dcca372ad8b8bce8829a7c18ca462d77a98c540e"
+  integrity sha512-nTJyaC8nCnZUAvxn5l7NH25FyvgOGyp8HoAWZeddXW9k5tg6esQYfebauWQG0p4si/gcfk9LFCzyl0MLutMEUA==
   dependencies:
     "@lit/reactive-element" "1.0.0-rc.4"
-    "@material/base" "=13.0.0-canary.65125b3a6.0"
-    "@material/dom" "=13.0.0-canary.65125b3a6.0"
-    lit-element "^3.0.0"
+    "@material/base" "=14.0.0-canary.353ca7e9f.0"
+    "@material/dom" "=14.0.0-canary.353ca7e9f.0"
+    lit "^2.0.0"
     tslib "^2.0.1"
 
-"@material/mwc-checkbox@^0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-checkbox/-/mwc-checkbox-0.25.1.tgz#d461049f044f444d20a8f9d75bc14a824da37dec"
-  integrity sha512-3Yj9QBXcif9mUqHmUI1hKryv3m/GVZn1Y48YX8sg8I4UShri2BO5pmZs6DM4g1gtk1EseNI82bBCa9QttxXRLA==
+"@material/mwc-checkbox@^0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@material/mwc-checkbox/-/mwc-checkbox-0.25.2.tgz#d6977bd279b2f20fbe96a0ff605b62d33cc147bb"
+  integrity sha512-evuM8MpEjgzDtJLKNMtnrg7IXjWBtNEOQsDLm2wjvggQq3I3SAGYNbgh+sZG2a/1MlkfQ/mpWZp8ZnaD9ScjPg==
   dependencies:
-    "@material/mwc-base" "^0.25.1"
-    "@material/mwc-ripple" "^0.25.1"
-    lit-element "^3.0.0"
-    lit-html "^2.0.0"
+    "@material/mwc-base" "^0.25.2"
+    "@material/mwc-ripple" "^0.25.2"
+    lit "^2.0.0"
     tslib "^2.0.1"
 
-"@material/mwc-floating-label@^0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-floating-label/-/mwc-floating-label-0.25.1.tgz#a55124a41b2e525d6d4f67e2906b756863b27940"
-  integrity sha512-SqbDtl3d25Q5c2ou6XLF2p4wqB0bTJrzpbrm1oR86zt8Zj5FmYuLCCQ1EE8uhT0z1X2Hyzf2G5Rb+KqsiC+ljQ==
+"@material/mwc-floating-label@^0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@material/mwc-floating-label/-/mwc-floating-label-0.25.2.tgz#d636493e8306ebf7e4bd8616a02686cc8bcd6886"
+  integrity sha512-1WbIVOnxJefPVtdlwoc5YNa5cFlw/J6HFxuXTc4JaDZHOpBk/HHV7VWKfmcZVJXCrgZGoWGjfogkEUvrNTVD+w==
   dependencies:
-    "@material/floating-label" "=13.0.0-canary.65125b3a6.0"
-    lit-element "^3.0.0"
-    lit-html "^2.0.0"
+    "@material/floating-label" "=14.0.0-canary.353ca7e9f.0"
+    lit "^2.0.0"
     tslib "^2.0.1"
 
-"@material/mwc-formfield@^0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-formfield/-/mwc-formfield-0.25.1.tgz#06a227b2d6056ff2f05a3b98085eed5cdd7f427d"
-  integrity sha512-CkVUjSZAL50vtSjvtKSebflRICsdAzbQ0j6mooITp7N+M2TgCInVAdvQ4YViZN54aWtgVAVxcNPXqUdHKrohQw==
+"@material/mwc-formfield@^0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@material/mwc-formfield/-/mwc-formfield-0.25.2.tgz#88c3da33944f236b14d5f7281e43a4bb1e9e8612"
+  integrity sha512-ECmLgyPF05np7I/pILYpVc2Siz9S7EjfTPISMb8+AIZr5Ahs3Olk1LvI/fYA9BggVP6Voin1rYuf1Q/GiCr/GA==
   dependencies:
-    "@material/form-field" "=13.0.0-canary.65125b3a6.0"
-    "@material/mwc-base" "^0.25.1"
-    lit-element "^3.0.0"
-    lit-html "^2.0.0"
+    "@material/form-field" "=14.0.0-canary.353ca7e9f.0"
+    "@material/mwc-base" "^0.25.2"
+    lit "^2.0.0"
     tslib "^2.0.1"
 
-"@material/mwc-icon-button@^0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-icon-button/-/mwc-icon-button-0.25.1.tgz#f0306c5d04b3226494ad093ee71fee9c63e269ac"
-  integrity sha512-rJqsQe4F2rkQ4cwAB1jLmkwN+f2vjD9CKS5nB7mdLkBqDrDwcb4fs7BJCZDe36zKtHoZwiReh4auMn+x6sU79A==
+"@material/mwc-icon-button@^0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@material/mwc-icon-button/-/mwc-icon-button-0.25.2.tgz#de393aa2c05e4f1a03412f889bf90c5991c484b9"
+  integrity sha512-OHbTkux0j4eDdK8Aa7Zi729vRfTWh730/ZjgvN6Q//Lh7x+QiWeapfeUA615hvftCvhFhzI7Zo0a+TBxOqce4A==
   dependencies:
-    "@material/mwc-ripple" "^0.25.1"
-    lit-element "^3.0.0"
+    "@material/mwc-ripple" "^0.25.2"
+    lit "^2.0.0"
     tslib "^2.0.1"
 
-"@material/mwc-icon@^0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-icon/-/mwc-icon-0.25.1.tgz#a0bf7b6dffddf3ab5e3a6cf3645e50ef0963742b"
-  integrity sha512-vOftTvOYNN4H+p/4/RddaS6facGQIMUoaE0tl5PrGsxqCilZNFMyHNShu/wZ0OfVHJmv32I14kfTGIf6kJZx4g==
+"@material/mwc-icon@^0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@material/mwc-icon/-/mwc-icon-0.25.2.tgz#6f491d5c3acadbbf4a91ea04e97e92f6a65af897"
+  integrity sha512-W0qJRUE7Q2nFkOwV+8rlDXaRgZtH0FaWr1C2nUykv4IqXLeAGIb9u6XSuDCbBxuvHeqG2hFmEbfQ5zJoWU21kw==
   dependencies:
-    lit-element "^3.0.0"
+    lit "^2.0.0"
     tslib "^2.0.1"
 
-"@material/mwc-line-ripple@^0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-line-ripple/-/mwc-line-ripple-0.25.1.tgz#f8ba2a96b01f23ef2fd878a9d82a5a4360442538"
-  integrity sha512-fGOV1U257LPv6rHZbDXcUz3lOEtuJXtV5cSQrViggFQYRG5BLCmwKM0+QLv38hV7leOGmCREKF+ftgrknNM5yg==
+"@material/mwc-line-ripple@^0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@material/mwc-line-ripple/-/mwc-line-ripple-0.25.2.tgz#1ea91754efb70ca15f8cdd356c7fa47b35caf814"
+  integrity sha512-8vuKpcXghxd5Jw7gPL3gvUIO1HVR+joy/8bnawbRHi456QDsPaZEewyBB1vYstW7OssOLWJwKfvfRgrNYP47Ag==
   dependencies:
-    "@material/line-ripple" "=13.0.0-canary.65125b3a6.0"
-    lit-element "^3.0.0"
-    lit-html "^2.0.0"
+    "@material/line-ripple" "=14.0.0-canary.353ca7e9f.0"
+    lit "^2.0.0"
     tslib "^2.0.1"
 
-"@material/mwc-list@^0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-list/-/mwc-list-0.25.1.tgz#cb4e308a46864bb72c14154643804d6de1d38948"
-  integrity sha512-jEG5c4EMEUdxlyAAWRp7zJLYoyfnDOupfZaHW59R7PNSh7rG0JJ4FwGYjaYVNlgcl8QY5CBr2JPQMBlprwvHBQ==
+"@material/mwc-list@^0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@material/mwc-list/-/mwc-list-0.25.2.tgz#c83ecefedd63a68651498e7c42c367bb6ed0dacc"
+  integrity sha512-qIiFo9L3+/IDhcf4isgb1ZKI5SshXuWzTfZKcnoDkyUS4KdaoOuNqpwM7K34g4+m2Ocwjyj6kzjLTqMhtLiC7A==
   dependencies:
-    "@material/base" "=13.0.0-canary.65125b3a6.0"
-    "@material/dom" "=13.0.0-canary.65125b3a6.0"
-    "@material/list" "=13.0.0-canary.65125b3a6.0"
-    "@material/mwc-base" "^0.25.1"
-    "@material/mwc-checkbox" "^0.25.1"
-    "@material/mwc-radio" "^0.25.1"
-    "@material/mwc-ripple" "^0.25.1"
-    lit-element "^3.0.0"
-    lit-html "^2.0.0"
+    "@material/base" "=14.0.0-canary.353ca7e9f.0"
+    "@material/dom" "=14.0.0-canary.353ca7e9f.0"
+    "@material/list" "=14.0.0-canary.353ca7e9f.0"
+    "@material/mwc-base" "^0.25.2"
+    "@material/mwc-checkbox" "^0.25.2"
+    "@material/mwc-radio" "^0.25.2"
+    "@material/mwc-ripple" "^0.25.2"
+    lit "^2.0.0"
     tslib "^2.0.1"
 
-"@material/mwc-menu@^0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-menu/-/mwc-menu-0.25.1.tgz#aea1f1d3dc3ee8a68d7ae066d911015369654158"
-  integrity sha512-aiBCqipi8p8Z0uJ5Cn1ntdDhq/mQvPQ+GoiK1ctmwhc1DvSve1aMRuwpkCxMqxH2qwK7/pSuVR2WZnwMuLA7Mw==
+"@material/mwc-menu@^0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@material/mwc-menu/-/mwc-menu-0.25.2.tgz#995ba6eeaa917a606fede9013b83b70cffd611bf"
+  integrity sha512-Cm+k5m8iDLXVBt9Suq3xtJjXWhaiyQ+byXGqxVjCK3MacmzXA1NHDe+Hbk47WTmaN5QMug9Ywl63OCz1VhqOSA==
   dependencies:
-    "@material/menu" "=13.0.0-canary.65125b3a6.0"
-    "@material/menu-surface" "=13.0.0-canary.65125b3a6.0"
-    "@material/mwc-base" "^0.25.1"
-    "@material/mwc-list" "^0.25.1"
-    "@material/shape" "=13.0.0-canary.65125b3a6.0"
-    "@material/theme" "=13.0.0-canary.65125b3a6.0"
-    lit-element "^3.0.0"
-    lit-html "^2.0.0"
+    "@material/menu" "=14.0.0-canary.353ca7e9f.0"
+    "@material/menu-surface" "=14.0.0-canary.353ca7e9f.0"
+    "@material/mwc-base" "^0.25.2"
+    "@material/mwc-list" "^0.25.2"
+    "@material/shape" "=14.0.0-canary.353ca7e9f.0"
+    "@material/theme" "=14.0.0-canary.353ca7e9f.0"
+    lit "^2.0.0"
     tslib "^2.0.1"
 
-"@material/mwc-notched-outline@^0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-notched-outline/-/mwc-notched-outline-0.25.1.tgz#44e501d6e3ef788c86220f7e07a8dcebcbdd0867"
-  integrity sha512-VmStGhOFY76UKOhTWXgwLVyR4FEqgWwUW5iSkFZZVq6oYKN9kAcdyoHTn3fWfrO/W4UYO8/EErY9SYUuFwyNdA==
+"@material/mwc-notched-outline@^0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@material/mwc-notched-outline/-/mwc-notched-outline-0.25.2.tgz#9b085a72f50b37de4d809e894faf4dae51603d44"
+  integrity sha512-llN+mkgl6/QwOAz++DRPes4R1NO1iB+rphWoH4UGnHYrMt5BCw5SZ2YQN6cY6Icaqr21PQIHCdRTKLSAa/z7lw==
   dependencies:
-    "@material/mwc-base" "^0.25.1"
-    "@material/notched-outline" "=13.0.0-canary.65125b3a6.0"
-    lit-element "^3.0.0"
-    lit-html "^2.0.0"
+    "@material/mwc-base" "^0.25.2"
+    "@material/notched-outline" "=14.0.0-canary.353ca7e9f.0"
+    lit "^2.0.0"
     tslib "^2.0.1"
 
-"@material/mwc-radio@^0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-radio/-/mwc-radio-0.25.1.tgz#e79f0d95921924b98e4a60bf156c9eb2fdddbdf9"
-  integrity sha512-xx307iuUKpyYvWOl2SmbJsufGLE9fhGK0R0iZ4ZCc8t6NrBy9WilGzzZVeyn1KRGG9AYWwe4mfLXnrSiqnQYpg==
+"@material/mwc-radio@^0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@material/mwc-radio/-/mwc-radio-0.25.2.tgz#de37074aa1b5e8815870bfae9a8b0c01fac125df"
+  integrity sha512-V3WojFgGoYYBKhlXm34Gacr4yGW+sA5uJO7JiZA9bbET1TLuRjhE5Z9EuKS/JmGkHr3o5t/0lPvENR3pBGpvVQ==
   dependencies:
-    "@material/mwc-base" "^0.25.1"
-    "@material/mwc-ripple" "^0.25.1"
-    "@material/radio" "=13.0.0-canary.65125b3a6.0"
-    lit-element "^3.0.0"
+    "@material/mwc-base" "^0.25.2"
+    "@material/mwc-ripple" "^0.25.2"
+    "@material/radio" "=14.0.0-canary.353ca7e9f.0"
+    lit "^2.0.0"
     tslib "^2.0.1"
 
-"@material/mwc-ripple@^0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-ripple/-/mwc-ripple-0.25.1.tgz#40813243c39fba69529b9e5cf1b0b65d692187ac"
-  integrity sha512-e7TsseFzbo6TIMEJZNDB0XVbr7ks3PJyF5kVLAZjvItKLlqFoYMvrMAkc8bUGNbRpgIKUWDoabogoduk+iubfw==
+"@material/mwc-ripple@^0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@material/mwc-ripple/-/mwc-ripple-0.25.2.tgz#c697c94c53dd016dcd2ae6cbc2609c58b003d161"
+  integrity sha512-z39JamHlKVEG0nRfyJeFUACbGjP6AqP0uUamE7qFtuJFQTlCU/jvdBoFdNo5V3xtKIN3/iH8ca3BXVxRC8u63A==
   dependencies:
-    "@material/dom" "=13.0.0-canary.65125b3a6.0"
-    "@material/mwc-base" "^0.25.1"
-    "@material/ripple" "=13.0.0-canary.65125b3a6.0"
-    lit-element "^3.0.0"
-    lit-html "^2.0.0"
+    "@material/dom" "=14.0.0-canary.353ca7e9f.0"
+    "@material/mwc-base" "^0.25.2"
+    "@material/ripple" "=14.0.0-canary.353ca7e9f.0"
+    lit "^2.0.0"
     tslib "^2.0.1"
 
-"@material/mwc-select@^0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-select/-/mwc-select-0.25.1.tgz#414f0b75c8d97dbece6fcc60f1fcd977ab8c8372"
-  integrity sha512-2gp4K2waKAvFJ0Mc99DbrKhAOwFmLprguSX7tWGG5MQtf6eP/0gAFOl6tA7rQx42gzjS/CtfvhebeXguiKpYaQ==
+"@material/mwc-select@^0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@material/mwc-select/-/mwc-select-0.25.2.tgz#db7b5efd0373be151909900f1d236652492e8264"
+  integrity sha512-SAr2mwnZYjZ9aZ+OAEmgiFbbHB48ElLsxrBIgjB+29LwgARap4jgQAlh9W26MuLuE95gHQgITH15SAMKrqbDlg==
   dependencies:
-    "@material/dom" "=13.0.0-canary.65125b3a6.0"
-    "@material/floating-label" "=13.0.0-canary.65125b3a6.0"
-    "@material/line-ripple" "=13.0.0-canary.65125b3a6.0"
-    "@material/list" "=13.0.0-canary.65125b3a6.0"
-    "@material/mwc-base" "^0.25.1"
-    "@material/mwc-floating-label" "^0.25.1"
-    "@material/mwc-icon" "^0.25.1"
-    "@material/mwc-line-ripple" "^0.25.1"
-    "@material/mwc-list" "^0.25.1"
-    "@material/mwc-menu" "^0.25.1"
-    "@material/mwc-notched-outline" "^0.25.1"
-    "@material/select" "=13.0.0-canary.65125b3a6.0"
-    lit-element "^3.0.0"
-    lit-html "^2.0.0"
+    "@material/dom" "=14.0.0-canary.353ca7e9f.0"
+    "@material/floating-label" "=14.0.0-canary.353ca7e9f.0"
+    "@material/line-ripple" "=14.0.0-canary.353ca7e9f.0"
+    "@material/list" "=14.0.0-canary.353ca7e9f.0"
+    "@material/mwc-base" "^0.25.2"
+    "@material/mwc-floating-label" "^0.25.2"
+    "@material/mwc-icon" "^0.25.2"
+    "@material/mwc-line-ripple" "^0.25.2"
+    "@material/mwc-list" "^0.25.2"
+    "@material/mwc-menu" "^0.25.2"
+    "@material/mwc-notched-outline" "^0.25.2"
+    "@material/select" "=14.0.0-canary.353ca7e9f.0"
+    lit "^2.0.0"
     tslib "^2.0.1"
 
-"@material/mwc-textfield@^0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-textfield/-/mwc-textfield-0.25.1.tgz#1c68544ebc684c299c6ed4a08a57578b9e3d5b28"
-  integrity sha512-Xeze6MHWaAQB/xjwJ1y/guZh6JaaeLYTCMvhyk7m+oVTOQebwa490Oktzyw265p8iOthH8Fby7+UjX2MZ3gpvQ==
+"@material/mwc-textfield@^0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@material/mwc-textfield/-/mwc-textfield-0.25.2.tgz#4dddb4cd4f60288a1890c4424e8dda0007649f78"
+  integrity sha512-MWxfOryo1r0KLoHBwZ77tonga2yB6dFof0z8mC1XJEvr7QGK6HqiaR+U+bQkxygxd5+ZCBn+pCR+Aii/TTKpDA==
   dependencies:
-    "@material/floating-label" "=13.0.0-canary.65125b3a6.0"
-    "@material/line-ripple" "=13.0.0-canary.65125b3a6.0"
-    "@material/mwc-base" "^0.25.1"
-    "@material/mwc-floating-label" "^0.25.1"
-    "@material/mwc-line-ripple" "^0.25.1"
-    "@material/mwc-notched-outline" "^0.25.1"
-    "@material/textfield" "=13.0.0-canary.65125b3a6.0"
-    lit-element "^3.0.0"
-    lit-html "^2.0.0"
+    "@material/floating-label" "=14.0.0-canary.353ca7e9f.0"
+    "@material/line-ripple" "=14.0.0-canary.353ca7e9f.0"
+    "@material/mwc-base" "^0.25.2"
+    "@material/mwc-floating-label" "^0.25.2"
+    "@material/mwc-line-ripple" "^0.25.2"
+    "@material/mwc-notched-outline" "^0.25.2"
+    "@material/textfield" "=14.0.0-canary.353ca7e9f.0"
+    lit "^2.0.0"
     tslib "^2.0.1"
 
-"@material/notched-outline@13.0.0-canary.65125b3a6.0", "@material/notched-outline@=13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/notched-outline/-/notched-outline-13.0.0-canary.65125b3a6.0.tgz#648a7e09d4a0a67adfab1d47dd9dd3f357fa508a"
-  integrity sha512-dfOy7N/5KgRgIE3pIoJje8fTnuIh6JhQKb9CywkDtpvq/a0xEmWQDy3L4fIgkSkNF47s09sQ1r7AxNDbSLzMgQ==
+"@material/notched-outline@14.0.0-canary.353ca7e9f.0", "@material/notched-outline@=14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/notched-outline/-/notched-outline-14.0.0-canary.353ca7e9f.0.tgz#a6aa4ca23f0f5cca995e2804b9b866989205d4ca"
+  integrity sha512-Y3j/+9IE/8rWio7cUvvsXbDGR6cJ2YJC1x53ZaXHjt4ZhBtlWkGRDJ2/dIk5ZEsvTyaTZlbU8sYJeMBuI06xQA==
   dependencies:
-    "@material/base" "13.0.0-canary.65125b3a6.0"
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
-    "@material/floating-label" "13.0.0-canary.65125b3a6.0"
-    "@material/rtl" "13.0.0-canary.65125b3a6.0"
-    "@material/shape" "13.0.0-canary.65125b3a6.0"
-    "@material/theme" "13.0.0-canary.65125b3a6.0"
+    "@material/base" "14.0.0-canary.353ca7e9f.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
+    "@material/floating-label" "14.0.0-canary.353ca7e9f.0"
+    "@material/rtl" "14.0.0-canary.353ca7e9f.0"
+    "@material/shape" "14.0.0-canary.353ca7e9f.0"
+    "@material/theme" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/radio@=13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/radio/-/radio-13.0.0-canary.65125b3a6.0.tgz#e33ca71fdb32a168bcc0e1aca4b9dab9bceb7811"
-  integrity sha512-NAADe8zDV0a5dbMm45u8AGqpAYttk9EWQaNWhoh3SvkxdVQGAKXmXwXWr6EPkz/8/otrbW/Ak0sEiUDZiEYUVQ==
+"@material/radio@=14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/radio/-/radio-14.0.0-canary.353ca7e9f.0.tgz#2495781d125e771241de3b9c29227c3837da056b"
+  integrity sha512-EIfbeB5ZOEyj24SHUzOzI+cpFYNdKbFtcetMejxUR74ZfkknRmpLuFydmR2gqyYLKV/dagY6MKplLzzXtDh8LA==
   dependencies:
-    "@material/animation" "13.0.0-canary.65125b3a6.0"
-    "@material/base" "13.0.0-canary.65125b3a6.0"
-    "@material/density" "13.0.0-canary.65125b3a6.0"
-    "@material/dom" "13.0.0-canary.65125b3a6.0"
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
-    "@material/ripple" "13.0.0-canary.65125b3a6.0"
-    "@material/theme" "13.0.0-canary.65125b3a6.0"
-    "@material/touch-target" "13.0.0-canary.65125b3a6.0"
+    "@material/animation" "14.0.0-canary.353ca7e9f.0"
+    "@material/base" "14.0.0-canary.353ca7e9f.0"
+    "@material/density" "14.0.0-canary.353ca7e9f.0"
+    "@material/dom" "14.0.0-canary.353ca7e9f.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
+    "@material/ripple" "14.0.0-canary.353ca7e9f.0"
+    "@material/theme" "14.0.0-canary.353ca7e9f.0"
+    "@material/touch-target" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/ripple@13.0.0-canary.65125b3a6.0", "@material/ripple@=13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-13.0.0-canary.65125b3a6.0.tgz#3d955eccdad6130b822ff4afafc3e1223337fb38"
-  integrity sha512-UNEXw/i1ol7BuTFcERFi1X26SxKioIEIT3nJL2j5pist29+7seKaJvUvd9UyNHJ9R6f8+GtaLKFpCngePiiVWQ==
+"@material/ripple@14.0.0-canary.353ca7e9f.0", "@material/ripple@=14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-14.0.0-canary.353ca7e9f.0.tgz#3388c7231d450ff749d3952b288580f71516aee0"
+  integrity sha512-5/n2bZ2TmVJGDzSn0jjHHaI21h2tgTADxVocSzecXUFj/XuHOHlIVIPQRlNOYhx/ZG1rD2DOdLNi+CemBizZqQ==
   dependencies:
-    "@material/animation" "13.0.0-canary.65125b3a6.0"
-    "@material/base" "13.0.0-canary.65125b3a6.0"
-    "@material/dom" "13.0.0-canary.65125b3a6.0"
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
-    "@material/rtl" "13.0.0-canary.65125b3a6.0"
-    "@material/theme" "13.0.0-canary.65125b3a6.0"
+    "@material/animation" "14.0.0-canary.353ca7e9f.0"
+    "@material/base" "14.0.0-canary.353ca7e9f.0"
+    "@material/dom" "14.0.0-canary.353ca7e9f.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
+    "@material/rtl" "14.0.0-canary.353ca7e9f.0"
+    "@material/theme" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/rtl@13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-13.0.0-canary.65125b3a6.0.tgz#9ee4058850cc86078a02e1cffd61b50a6a6470d5"
-  integrity sha512-lF5MerNaNYyadKIAnBW4OGLZPUC+9vOUDx7zFPphGw+f6hyBETjoK7MLfozl6LRJgr86jnoPXBVJy/vOgks26Q==
+"@material/rtl@14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-14.0.0-canary.353ca7e9f.0.tgz#7bfab7979ef9ea4ac344f4fabbbd2d176501e3f9"
+  integrity sha512-3NuIyWGSPyc4ZzxBRjZvMNmGodrOYNmD4ef1CCT0erfVP7/DFyEaFcIkwfqQJo2vL/j+IiKq/mS4f2kekLjPdQ==
   dependencies:
-    "@material/theme" "13.0.0-canary.65125b3a6.0"
+    "@material/theme" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/select@=13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/select/-/select-13.0.0-canary.65125b3a6.0.tgz#7dcfdc34eeb6c574fb581cf1c25c2355fb4ee055"
-  integrity sha512-glNz8T77GxguTLAWKCjZC/zalp97aY/noIhNTD0A6rhfIMincW4APweuhvuPTAORP5euudBE8XvDFyfY2jttZg==
+"@material/select@=14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/select/-/select-14.0.0-canary.353ca7e9f.0.tgz#e517f6178a7a5ee922195d6cc50db24b9ba94ca3"
+  integrity sha512-Z5Hu2EWvAZDlOGxp/lPkWWUO7a4PgpGK5YhFky0SViWc5MYpgab3V2LT6zV5Op1CIPH+Xvf4QQL9JSYh1KPZUQ==
   dependencies:
-    "@material/animation" "13.0.0-canary.65125b3a6.0"
-    "@material/base" "13.0.0-canary.65125b3a6.0"
-    "@material/density" "13.0.0-canary.65125b3a6.0"
-    "@material/dom" "13.0.0-canary.65125b3a6.0"
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
-    "@material/floating-label" "13.0.0-canary.65125b3a6.0"
-    "@material/line-ripple" "13.0.0-canary.65125b3a6.0"
-    "@material/list" "13.0.0-canary.65125b3a6.0"
-    "@material/menu" "13.0.0-canary.65125b3a6.0"
-    "@material/menu-surface" "13.0.0-canary.65125b3a6.0"
-    "@material/notched-outline" "13.0.0-canary.65125b3a6.0"
-    "@material/ripple" "13.0.0-canary.65125b3a6.0"
-    "@material/rtl" "13.0.0-canary.65125b3a6.0"
-    "@material/shape" "13.0.0-canary.65125b3a6.0"
-    "@material/theme" "13.0.0-canary.65125b3a6.0"
-    "@material/typography" "13.0.0-canary.65125b3a6.0"
+    "@material/animation" "14.0.0-canary.353ca7e9f.0"
+    "@material/base" "14.0.0-canary.353ca7e9f.0"
+    "@material/density" "14.0.0-canary.353ca7e9f.0"
+    "@material/dom" "14.0.0-canary.353ca7e9f.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
+    "@material/floating-label" "14.0.0-canary.353ca7e9f.0"
+    "@material/line-ripple" "14.0.0-canary.353ca7e9f.0"
+    "@material/list" "14.0.0-canary.353ca7e9f.0"
+    "@material/menu" "14.0.0-canary.353ca7e9f.0"
+    "@material/menu-surface" "14.0.0-canary.353ca7e9f.0"
+    "@material/notched-outline" "14.0.0-canary.353ca7e9f.0"
+    "@material/ripple" "14.0.0-canary.353ca7e9f.0"
+    "@material/rtl" "14.0.0-canary.353ca7e9f.0"
+    "@material/shape" "14.0.0-canary.353ca7e9f.0"
+    "@material/theme" "14.0.0-canary.353ca7e9f.0"
+    "@material/typography" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/shape@13.0.0-canary.65125b3a6.0", "@material/shape@=13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/shape/-/shape-13.0.0-canary.65125b3a6.0.tgz#178db2527d0fbfe0d1645ff5d9aa4f3901f24c0d"
-  integrity sha512-XHUqI4ILpPalZyOwnhG218KkNeBvE29SmFDmOD1DgSswLp9UzI+00WPA42gciVTbme5dlwRyeoSBJ/niVRoOZQ==
+"@material/shape@14.0.0-canary.353ca7e9f.0", "@material/shape@=14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/shape/-/shape-14.0.0-canary.353ca7e9f.0.tgz#19f008cead59398b0e0a0af9f4c2b2cccc7a5564"
+  integrity sha512-4hwv3X6UpYwRDIOL9w3emRENfqGGr/bNcikV4FydDFbL9fIc3gfxXhaYU/mk+JXY0OZE/UG86YFGZq5pKcKQvg==
   dependencies:
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
-    "@material/rtl" "13.0.0-canary.65125b3a6.0"
-    "@material/theme" "13.0.0-canary.65125b3a6.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
+    "@material/rtl" "14.0.0-canary.353ca7e9f.0"
+    "@material/theme" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/textfield@=13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/textfield/-/textfield-13.0.0-canary.65125b3a6.0.tgz#83b51a24b55aeabe9c2e2fb130175abbe47cf0f5"
-  integrity sha512-CmniGzWYtXVb7rP1U/BZnht1Y3WJHOMQ5BJDJwxT+Z4fxKtG9jChMERM5jNO7avP/Y2/ya117opq0fodUZYJpg==
+"@material/textfield@=14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/textfield/-/textfield-14.0.0-canary.353ca7e9f.0.tgz#6a32629d89e716529415ee2dc406f3518b8d2ac2"
+  integrity sha512-Pttaq+VYGQEaOdBeVA+p5FJPPPjMQj+kR2JmB4/x6Gh3zBHWE5lS9Be10V2I9rfICE/nxEVIdQl2EyMf1U+kNw==
   dependencies:
-    "@material/animation" "13.0.0-canary.65125b3a6.0"
-    "@material/base" "13.0.0-canary.65125b3a6.0"
-    "@material/density" "13.0.0-canary.65125b3a6.0"
-    "@material/dom" "13.0.0-canary.65125b3a6.0"
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
-    "@material/floating-label" "13.0.0-canary.65125b3a6.0"
-    "@material/line-ripple" "13.0.0-canary.65125b3a6.0"
-    "@material/notched-outline" "13.0.0-canary.65125b3a6.0"
-    "@material/ripple" "13.0.0-canary.65125b3a6.0"
-    "@material/rtl" "13.0.0-canary.65125b3a6.0"
-    "@material/shape" "13.0.0-canary.65125b3a6.0"
-    "@material/theme" "13.0.0-canary.65125b3a6.0"
-    "@material/typography" "13.0.0-canary.65125b3a6.0"
+    "@material/animation" "14.0.0-canary.353ca7e9f.0"
+    "@material/base" "14.0.0-canary.353ca7e9f.0"
+    "@material/density" "14.0.0-canary.353ca7e9f.0"
+    "@material/dom" "14.0.0-canary.353ca7e9f.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
+    "@material/floating-label" "14.0.0-canary.353ca7e9f.0"
+    "@material/line-ripple" "14.0.0-canary.353ca7e9f.0"
+    "@material/notched-outline" "14.0.0-canary.353ca7e9f.0"
+    "@material/ripple" "14.0.0-canary.353ca7e9f.0"
+    "@material/rtl" "14.0.0-canary.353ca7e9f.0"
+    "@material/shape" "14.0.0-canary.353ca7e9f.0"
+    "@material/theme" "14.0.0-canary.353ca7e9f.0"
+    "@material/typography" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/theme@13.0.0-canary.65125b3a6.0", "@material/theme@=13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-13.0.0-canary.65125b3a6.0.tgz#0124bf87b8650f4fd386d0a1b2f8da25f563e24a"
-  integrity sha512-zCnewyS+owjcEx9r+tk8z2M1+yajouUXzisvqOoffg4cZpviFaeaoIwq9TblJ4Ob8UGt8mjNvXniL7Ik0z6bYQ==
+"@material/theme@14.0.0-canary.353ca7e9f.0", "@material/theme@=14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-14.0.0-canary.353ca7e9f.0.tgz#da8073da05ebc4629dcb6feac4e60a86e46de20f"
+  integrity sha512-1gWWB6ZuKoNDwWpeCbxu2UYWRAhuRW25KWPw4tZIOw2jwN6gqptgyyweC18vLhT/YuSvq15bReiAeo7WyOfg6A==
   dependencies:
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/touch-target@13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/touch-target/-/touch-target-13.0.0-canary.65125b3a6.0.tgz#2a31a55b17d498aea666814752b2c72db75d828e"
-  integrity sha512-HyxWIz8uPKNOB+/FxsTLX/Y2CqiWEjYeHSZPIB993YSfSuIaEHHN5Zq9NHQ4D1Uh6XYb3md0cdImOmJ+LLymkA==
+"@material/touch-target@14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/touch-target/-/touch-target-14.0.0-canary.353ca7e9f.0.tgz#edfb35011163352320c7066034d4684f3d7f2108"
+  integrity sha512-EiA1zWwC3/gAIkj3w+Sqp4CCd9Mh1tmtpGPfJXLSIkYildmDRmKw/QlqjYCfrGiFcWSx5aecJ/ALtFKUzApq9A==
   dependencies:
-    "@material/base" "13.0.0-canary.65125b3a6.0"
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
-    "@material/rtl" "13.0.0-canary.65125b3a6.0"
+    "@material/base" "14.0.0-canary.353ca7e9f.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
+    "@material/rtl" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
-"@material/typography@13.0.0-canary.65125b3a6.0":
-  version "13.0.0-canary.65125b3a6.0"
-  resolved "https://registry.yarnpkg.com/@material/typography/-/typography-13.0.0-canary.65125b3a6.0.tgz#53fe199d10b8366b5cbba242000e69c1965e0a33"
-  integrity sha512-SPulUyj9p5CQO0GffzcwVdAUpObpB3ygJWl61QTeggOSdUS279GpFAzAhJxUmDeHQfIv9YR3RaPwO71Rc0bJPA==
+"@material/typography@14.0.0-canary.353ca7e9f.0":
+  version "14.0.0-canary.353ca7e9f.0"
+  resolved "https://registry.yarnpkg.com/@material/typography/-/typography-14.0.0-canary.353ca7e9f.0.tgz#3c6b12194edf7fe438f97dad33a4eba9a7fe4053"
+  integrity sha512-tUBTk+wv4gou+NfloCRPbGpakQL0pvoTJmP5yCgvDdVqBeBxN+8BByPi03LNey7wQnsuZSik5mpQERuqoBp7Yw==
   dependencies:
-    "@material/feature-targeting" "13.0.0-canary.65125b3a6.0"
-    "@material/theme" "13.0.0-canary.65125b3a6.0"
+    "@material/feature-targeting" "14.0.0-canary.353ca7e9f.0"
+    "@material/theme" "14.0.0-canary.353ca7e9f.0"
     tslib "^2.1.0"
 
 "@mdi/font@^6.2.95":
@@ -3486,7 +3476,7 @@ lit-html@^2.0.0:
   dependencies:
     "@types/trusted-types" "^2.0.2"
 
-lit@^2.0.2:
+lit@^2.0.0, lit@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lit/-/lit-2.0.2.tgz#5e6f422924e0732258629fb379556b6d23f7179c"
   integrity sha512-hKA/1YaSB+P+DvKWuR2q1Xzy/iayhNrJ3aveD0OQ9CKn6wUjsdnF/7LavDOJsKP/K5jzW/kXsuduPgRvTFrFJw==


### PR DESCRIPTION
Replaces https://github.com/home-assistant/analytics.home-assistant.io/pull/375
Replaces https://github.com/home-assistant/analytics.home-assistant.io/pull/374
Replaces https://github.com/home-assistant/analytics.home-assistant.io/pull/373
Replaces https://github.com/home-assistant/analytics.home-assistant.io/pull/371
Replaces https://github.com/home-assistant/analytics.home-assistant.io/pull/370
Replaces https://github.com/home-assistant/analytics.home-assistant.io/pull/369
Replaces https://github.com/home-assistant/analytics.home-assistant.io/pull/367