### PR TITLE
Rename Z-Wave JS UI addon

### DIFF
--- a/site/src/add-ons.html
+++ b/site/src/add-ons.html
@@ -197,9 +197,9 @@ addons_details:
     documentation: https://github.com/hassio-addons/repository/blob/master/zerotier/DOCS.md
     icon: https://raw.githubusercontent.com/hassio-addons/repository/master/zerotier/icon.png
   a0d7b954_zwavejs2mqtt:
-    name: Z-Wave JS to MQTT
-    documentation: https://github.com/hassio-addons/repository/blob/master/zwavejs2mqtt/DOCS.md
-    icon: https://raw.githubusercontent.com/hassio-addons/repository/master/zwavejs2mqtt/icon.png
+    name: Z-Wave JS UI
+    documentation: https://github.com/hassio-addons/repository/blob/master/zwave-js-ui/DOCS.md
+    icon: https://raw.githubusercontent.com/hassio-addons/repository/master/zwave-js-ui/icon.png
   5c53de3b_esphome:
     name: ESPHome
     documentation: https://github.com/esphome/home-assistant-addon/blob/main/esphome/DOCS.md


### PR DESCRIPTION
"Z-Wave JS to MQTT" is now known as "Z-Wave JS UI". 
See: https://github.com/hassio-addons/repository/commit/e85db0e78c03994a17fe723fee60164469427ac2