### PR TITLE
Bump @cloudflare/workers-types from 3.17.0 to 3.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@11ty/eleventy": "^1.0.2",
-    "@cloudflare/workers-types": "^3.17.0",
+    "@cloudflare/workers-types": "^3.18.0",
     "@cloudflare/wrangler": "^1.19.12",
     "@types/jest": "^27.5.0",
     "@types/node": "^18.11.9",

--- a/worker/src/handlers/post.ts
+++ b/worker/src/handlers/post.ts
@@ -34,9 +34,9 @@ export async function handlePost(
   let incomingPayload;
   sentry.addBreadcrumb({ message: "Process started" });
   const request_json = await request.json<Record<string, any>>();
-  if (request.cf) {
+  if (request.cf && "country" in request.cf) {
     request_json.country = request.cf.country;
-    if (withRegion.has(request_json.country)) {
+    if ("regionCode" in request.cf && withRegion.has(request_json.country)) {
       request_json.region = request.cf.regionCode;
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -335,10 +335,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cloudflare/workers-types@^3.17.0":
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.17.0.tgz#8cee4499019daa6a23c9cc5501aa8382bb94d4da"
-  integrity sha512-u0cUQ4ntWFFwn5jx0ETa2ItvwvfOMjyaKF2fX2vFVujrSgNES/PnvRzPAhdt9CMYAMidInm0MGkIjxHRsFBaeg==
+"@cloudflare/workers-types@^3.18.0":
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.18.0.tgz#b4177cbe9306d7df4654db594d6e77c036341d2e"
+  integrity sha512-ehKOJVLMeR+tZkYhWEaLYQxl0TaIZu/kE86HF3/RidR8Xv5LuQxpbh+XXAoKVqsaphWLhIgBhgnlN5HGdheXSQ==
 
 "@cloudflare/wrangler@^1.19.12":
   version "1.20.0"


### PR DESCRIPTION
Replaces https://github.com/home-assistant/analytics.home-assistant.io/pull/649 with the adjustments needed to use that version