### PR TITLE
Remove r from rdata key for Container version graph

### DIFF
--- a/site/.eleventy.js
+++ b/site/.eleventy.js
@@ -84,7 +84,7 @@ module.exports = function (eleventyConfig) {
     return JSON.stringify([
       dataTable.DataPoint({ data: data.total, label: "Total" }),
       dataTable.DataPoint({ data: data.os, label: "Operating System" }),
-      dataTable.DataPoint({ rdata: data.container, label: "Container" }),
+      dataTable.DataPoint({ data: data.container, label: "Container" }),
       dataTable.DataPoint({ data: data.core, label: "Core" }),
       dataTable.DataPoint({ data: data.supervised, label: "Supervised" }),
     ]);


### PR DESCRIPTION
Removes the starting "r" of "rdata" in the key for defining the "data" for the Container version graph, this additional "r" makes it so it currently does not show on the graph as it expects the key tp be "data".