### PR TITLE
Adjust max worker invocation value

### DIFF
--- a/worker/src/data.ts
+++ b/worker/src/data.ts
@@ -4,9 +4,9 @@ export const KV_KEY_CUSTOM_INTEGRATIONS = "custom_integrations";
 export const KV_KEY_ADDONS = "addons";
 export const KV_PREFIX_HISTORY = "history";
 export const KV_PREFIX_UUID = "uuid";
-export const KV_MAX_PROCESS_ENTRIES = 600;
+export const KV_MAX_PROCESS_ENTRIES = 800;
 
-export const SCHEMA_VERSION_QUEUE = 12;
+export const SCHEMA_VERSION_QUEUE = 13;
 export const SCHEMA_VERSION_ANALYTICS = 3;
 
 export const BRANDS_DOMAINS_URL =

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -174,7 +174,7 @@ async function processQueue(sentry: Toucan): Promise<void> {
     queue = createQueueDefaults();
 
     const kv_list = await listKV(KV_PREFIX_UUID);
-    maxWorkerInvocations -= Math.round(kv_list.length / 1000);
+    maxWorkerInvocations -= Math.floor(kv_list.length / 1000);
 
     sentry.addBreadcrumb({
       message: `${kv_list.length} entries`,

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -238,6 +238,10 @@ async function processQueue(sentry: Toucan): Promise<void> {
     }
   }
 
+  sentry.addBreadcrumb({
+    message: `${maxWorkerInvocations} remaining`,
+  });
+
   await Promise.all(
     queue.entries
       .splice(0, maxWorkerInvocations)

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -153,7 +153,7 @@ async function updateHistory(sentry: Toucan): Promise<void> {
 async function processQueue(sentry: Toucan): Promise<void> {
   sentry.setTag("scheduled-task", "PROCESS_QUEUE");
   sentry.addBreadcrumb({ message: "Process started" });
-  let maxWorkerInvokations = KV_MAX_PROCESS_ENTRIES;
+  let maxWorkerinvocations = KV_MAX_PROCESS_ENTRIES;
   let queue = await getQueueData();
 
   sentry.setExtra("queue", queue);
@@ -174,7 +174,7 @@ async function processQueue(sentry: Toucan): Promise<void> {
     queue = createQueueDefaults();
 
     const kv_list = await listKV(KV_PREFIX_UUID);
-    maxWorkerInvokations -= Math.round(kv_list.length / 1000);
+    maxWorkerinvocations -= Math.round(kv_list.length / 1000);
 
     sentry.addBreadcrumb({
       message: `${kv_list.length} entries`,
@@ -240,7 +240,7 @@ async function processQueue(sentry: Toucan): Promise<void> {
 
   await Promise.all(
     queue.entries
-      .splice(0, maxWorkerInvokations)
+      .splice(0, maxWorkerinvocations)
       .map((entryKey) => handleEntry(entryKey))
   );
 

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -153,7 +153,7 @@ async function updateHistory(sentry: Toucan): Promise<void> {
 async function processQueue(sentry: Toucan): Promise<void> {
   sentry.setTag("scheduled-task", "PROCESS_QUEUE");
   sentry.addBreadcrumb({ message: "Process started" });
-  let maxWorkerinvocations = KV_MAX_PROCESS_ENTRIES;
+  let maxWorkerInvocations = KV_MAX_PROCESS_ENTRIES;
   let queue = await getQueueData();
 
   sentry.setExtra("queue", queue);
@@ -174,7 +174,7 @@ async function processQueue(sentry: Toucan): Promise<void> {
     queue = createQueueDefaults();
 
     const kv_list = await listKV(KV_PREFIX_UUID);
-    maxWorkerinvocations -= Math.round(kv_list.length / 1000);
+    maxWorkerInvocations -= Math.round(kv_list.length / 1000);
 
     sentry.addBreadcrumb({
       message: `${kv_list.length} entries`,
@@ -240,7 +240,7 @@ async function processQueue(sentry: Toucan): Promise<void> {
 
   await Promise.all(
     queue.entries
-      .splice(0, maxWorkerinvocations)
+      .splice(0, maxWorkerInvocations)
       .map((entryKey) => handleEntry(entryKey))
   );
 


### PR DESCRIPTION
This reverts the change of #668.

Instead of that approach, this adds a local variable that will subtract the number of calls done by listing out the entries.
(count / 1000) as it lists 1000 pr call.
The API should be able to handle 1000 invocations, so with this, we might be able to push it up to 900/950 in the future.

Note: This is a "band-aid" fix as well as #668 was, even with this we will still see issues when we get > 800K, but I have a plan for that which can be implemented later.