### PR TITLE
Allow recorder engine in payload

### DIFF
--- a/worker/src/data.ts
+++ b/worker/src/data.ts
@@ -119,6 +119,7 @@ export interface QueueData {
     engines: {
       [engine: string]: {
         count_configured: number;
+        versions: Record<string, number>;
       };
     };
   };
@@ -202,7 +203,7 @@ export interface IncomingPayload {
   user_count?: number;
   certificate?: boolean;
   energy?: { configured: boolean };
-  recorder?: { engine: string };
+  recorder?: { engine: string; version: string };
   uuid: string;
   version: string;
 }

--- a/worker/src/data.ts
+++ b/worker/src/data.ts
@@ -6,7 +6,7 @@ export const KV_PREFIX_HISTORY = "history";
 export const KV_PREFIX_UUID = "uuid";
 export const KV_MAX_PROCESS_ENTRIES = 800;
 
-export const SCHEMA_VERSION_QUEUE = 13;
+export const SCHEMA_VERSION_QUEUE = 14;
 export const SCHEMA_VERSION_ANALYTICS = 3;
 
 export const BRANDS_DOMAINS_URL =
@@ -115,6 +115,13 @@ export interface QueueData {
   energy: {
     count_configured: number;
   };
+  recorder: {
+    engines: {
+      [engine: string]: {
+        count_configured: number;
+      };
+    };
+  };
 }
 
 export interface Queue {
@@ -195,6 +202,7 @@ export interface IncomingPayload {
   user_count?: number;
   certificate?: boolean;
   energy?: { configured: boolean };
+  recorder?: { engine: string };
   uuid: string;
   version: string;
 }
@@ -247,6 +255,9 @@ export const createQueueData = (): QueueData => ({
   certificate_count_configured: 0,
   energy: {
     count_configured: 0,
+  },
+  recorder: {
+    engines: {},
   },
 });
 

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -511,6 +511,15 @@ function combineEntryData(
     data.certificate_count_configured++;
   }
 
+  if (entrydata.recorder) {
+    if (!data.recorder.engines[entrydata.recorder.engine]) {
+      data.recorder.engines[entrydata.recorder.engine] = {
+        count_configured: 0,
+      };
+    }
+    data.recorder.engines[entrydata.recorder.engine].count_configured++;
+  }
+
   return data;
 }
 
@@ -541,6 +550,9 @@ const processQueueData = (data: QueueData) => {
     certificate_count_configured: data.certificate_count_configured,
     energy: {
       count_configured: data.energy.count_configured,
+    },
+    recorder: {
+      engines: data.recorder.engines,
     },
   };
 };

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -514,10 +514,18 @@ function combineEntryData(
   if (entrydata.recorder) {
     if (!data.recorder.engines[entrydata.recorder.engine]) {
       data.recorder.engines[entrydata.recorder.engine] = {
+        versions: {},
         count_configured: 0,
       };
     }
     data.recorder.engines[entrydata.recorder.engine].count_configured++;
+    data.recorder.engines[entrydata.recorder.engine].versions[
+      entrydata.recorder.version
+    ] = bumpValue(
+      data.recorder.engines[entrydata.recorder.engine].versions[
+        entrydata.recorder.version
+      ]
+    );
   }
 
   return data;
@@ -551,8 +559,6 @@ const processQueueData = (data: QueueData) => {
     energy: {
       count_configured: data.energy.count_configured,
     },
-    recorder: {
-      engines: data.recorder.engines,
-    },
+    recorder: data.recorder,
   };
 };

--- a/worker/src/utils/validate.ts
+++ b/worker/src/utils/validate.ts
@@ -40,6 +40,10 @@ const defaultTrue = coerce(boolean(), nullable(boolean()), (value) =>
   value === null ? true : value
 );
 
+const stringLowerCase = coerce(string(), string(), (value) =>
+  value.toLowerCase()
+);
+
 export const IncomingPayloadStruct = object({
   addon_count: optional(number()),
   addons: optional(
@@ -73,6 +77,7 @@ export const IncomingPayloadStruct = object({
     object({ board: string(), version: optional(nullable(string())) })
   ),
   energy: optional(object({ configured: boolean() })),
+  recorder: optional(object({ engine: stringLowerCase })),
   certificate: optional(boolean()),
   user_count: optional(number()),
   uuid: size(string(), 32, 32),

--- a/worker/src/utils/validate.ts
+++ b/worker/src/utils/validate.ts
@@ -77,7 +77,7 @@ export const IncomingPayloadStruct = object({
     object({ board: string(), version: optional(nullable(string())) })
   ),
   energy: optional(object({ configured: boolean() })),
-  recorder: optional(object({ engine: stringLowerCase })),
+  recorder: optional(object({ engine: stringLowerCase, version: string() })),
   certificate: optional(boolean()),
   user_count: optional(number()),
   uuid: size(string(), 32, 32),

--- a/worker/tests/utils/validate.spec.ts
+++ b/worker/tests/utils/validate.spec.ts
@@ -76,7 +76,7 @@ describe("createIncomingPayload", function () {
       region: "XX",
       state_count: 1,
       energy: { configured: true },
-      recorder: { engine: "Awesome_Engine" },
+      recorder: { engine: "Awesome_Engine", version: "123" },
       supervisor: { healthy: false, supported: true, arch: "amd64" },
       user_count: 1,
       certificate: true,
@@ -87,6 +87,7 @@ describe("createIncomingPayload", function () {
     expect(fullPayload.version).toBe(BASE_PAYLOAD.version);
     expect(fullPayload.energy!.configured).toBeTruthy();
     expect(fullPayload.recorder!.engine).toBe("awesome_engine");
+    expect(fullPayload.recorder!.version).toBe("123");
 
     const payloadWithoutArch = createIncomingPayload({
       ...payload,

--- a/worker/tests/utils/validate.spec.ts
+++ b/worker/tests/utils/validate.spec.ts
@@ -76,6 +76,7 @@ describe("createIncomingPayload", function () {
       region: "XX",
       state_count: 1,
       energy: { configured: true },
+      recorder: { engine: "Awesome_Engine" },
       supervisor: { healthy: false, supported: true, arch: "amd64" },
       user_count: 1,
       certificate: true,
@@ -84,14 +85,15 @@ describe("createIncomingPayload", function () {
     expect(fullPayload.uuid).toBe(BASE_PAYLOAD.uuid);
     expect(fullPayload.installation_type).toBe(BASE_PAYLOAD.installation_type);
     expect(fullPayload.version).toBe(BASE_PAYLOAD.version);
-    expect(fullPayload.energy.configured).toBeTruthy();
+    expect(fullPayload.energy!.configured).toBeTruthy();
+    expect(fullPayload.recorder!.engine).toBe("awesome_engine");
 
     const payloadWithoutArch = createIncomingPayload({
       ...payload,
       supervisor: { healthy: false, supported: true },
     });
 
-    expect(payloadWithoutArch.supervisor.arch).not.toBeDefined();
+    expect(payloadWithoutArch.supervisor!.arch).not.toBeDefined();
   });
 
   it("Default true", function () {
@@ -99,7 +101,7 @@ describe("createIncomingPayload", function () {
       ...BASE_PAYLOAD,
       addons: [{ ...ADDON, protected: null }],
     });
-    expect(payload.addons[0].protected).toBe(true);
+    expect(payload.addons![0].protected).toBe(true);
   });
 
   it("Default false", function () {
@@ -107,6 +109,6 @@ describe("createIncomingPayload", function () {
       ...BASE_PAYLOAD,
       addons: [{ ...ADDON, auto_update: null }],
     });
-    expect(payload.addons[0].auto_update).toBe(false);
+    expect(payload.addons![0].auto_update).toBe(false);
   });
 });


### PR DESCRIPTION
Allow the payload to be extended to include entries like:
```json
...
"recorder":{"engine":"sqlite","version":"123"},
...
```