### PR TITLE
Use 10 as cutoff for version filter on dev

### DIFF
--- a/worker/src/utils/group-versions.ts
+++ b/worker/src/utils/group-versions.ts
@@ -1,6 +1,7 @@
 export const groupVersions = (versions: Record<string, number>) => {
   const releases: Record<string, number> = {};
   const releases_filtered: Record<string, number> = {};
+  const filterLowerLimit = WORKER_ENV ? 10 : 100;
 
   Object.keys(versions).forEach((version) => {
     const key: string = version.split(".").slice(0, 2).join(".");
@@ -8,10 +9,10 @@ export const groupVersions = (versions: Record<string, number>) => {
   });
 
   Object.keys(releases)
-    .filter((key) => releases[key] > 100)
+    .filter((key) => releases[key] > filterLowerLimit)
     .forEach((key) => {
       releases_filtered[key] = releases[key];
     });
 
   return releases_filtered;
-}
+};

--- a/worker/src/utils/group-versions.ts
+++ b/worker/src/utils/group-versions.ts
@@ -1,7 +1,7 @@
 export const groupVersions = (versions: Record<string, number>) => {
   const releases: Record<string, number> = {};
   const releases_filtered: Record<string, number> = {};
-  const filterLowerLimit = WORKER_ENV ? 10 : 100;
+  const filterLowerLimit = WORKER_ENV === "dev" ? 10 : 100;
 
   Object.keys(versions).forEach((version) => {
     const key: string = version.split(".").slice(0, 2).join(".");

--- a/worker/tests/handlers/schedule.spec.ts
+++ b/worker/tests/handlers/schedule.spec.ts
@@ -29,6 +29,7 @@ describe("schedule handler", function () {
       })),
     }));
     (global as any).NETLIFY_BUILD_HOOK = "";
+    (global as any).WORKER_ENV = "production";
   });
 
   describe("Unexpected task", function () {

--- a/worker/tests/utils/group-versions.spec.ts
+++ b/worker/tests/utils/group-versions.spec.ts
@@ -1,24 +1,56 @@
-import { groupVersions } from "../../src/utils/group-versions"
+import { groupVersions } from "../../src/utils/group-versions";
 
-it("test", function () {
-  const data = {
-    "1970.1.0": 11,
-    "2021.4.0": 60,
-    "2021.4.1": 30,
-    "2021.4.2": 20,
-    "2021.5.0b0": 100,
-    "2021.5.0": 20,
-    "2021.5.5": 30,
-    "2021.6.0.dev20210517": 8,
-    "2021.6.0.dev20210506": 11,
-    "2021.6.0": 100,
-    "2021.7.0.dev20210601": 7,
-  };
-  const versions = {
-    "2021.4": 110,
-    "2021.5": 150,
-    "2021.6": 119,
-  };
+describe("groupVersions", function () {
+  afterEach(() => {
+    (global as any).WORKER_ENV = undefined;
+  });
 
-  expect(groupVersions(data)).toStrictEqual(versions);
+  it("test dev", function () {
+    (global as any).WORKER_ENV = "dev";
+    const data = {
+      "1970.1.0": 11,
+      "2021.4.0": 60,
+      "2021.4.1": 30,
+      "2021.4.2": 20,
+      "2021.5.0b0": 100,
+      "2021.5.0": 20,
+      "2021.5.5": 30,
+      "2021.6.0.dev20210517": 8,
+      "2021.6.0.dev20210506": 11,
+      "2021.6.0": 100,
+      "2021.7.0.dev20210601": 7,
+    };
+    const versions = {
+      "1970.1": 11,
+      "2021.4": 110,
+      "2021.5": 150,
+      "2021.6": 119,
+    };
+
+    expect(groupVersions(data)).toStrictEqual(versions);
+  });
+
+  it("test production", function () {
+    (global as any).WORKER_ENV = "production";
+    const data = {
+      "1970.1.0": 11,
+      "2021.4.0": 60,
+      "2021.4.1": 30,
+      "2021.4.2": 20,
+      "2021.5.0b0": 100,
+      "2021.5.0": 20,
+      "2021.5.5": 30,
+      "2021.6.0.dev20210517": 8,
+      "2021.6.0.dev20210506": 11,
+      "2021.6.0": 100,
+      "2021.7.0.dev20210601": 7,
+    };
+    const versions = {
+      "2021.4": 110,
+      "2021.5": 150,
+      "2021.6": 119,
+    };
+
+    expect(groupVersions(data)).toStrictEqual(versions);
+  });
 });

--- a/worker/tests/utils/group-versions.spec.ts
+++ b/worker/tests/utils/group-versions.spec.ts
@@ -1,5 +1,19 @@
 import { groupVersions } from "../../src/utils/group-versions";
 
+const sampleData = {
+  "1970.1.0": 11,
+  "2021.4.0": 60,
+  "2021.4.1": 30,
+  "2021.4.2": 20,
+  "2021.5.0b0": 100,
+  "2021.5.0": 20,
+  "2021.5.5": 30,
+  "2021.6.0.dev20210517": 8,
+  "2021.6.0.dev20210506": 11,
+  "2021.6.0": 100,
+  "2021.7.0.dev20210601": 7,
+};
+
 describe("groupVersions", function () {
   afterEach(() => {
     (global as any).WORKER_ENV = undefined;
@@ -7,50 +21,20 @@ describe("groupVersions", function () {
 
   it("test dev", function () {
     (global as any).WORKER_ENV = "dev";
-    const data = {
-      "1970.1.0": 11,
-      "2021.4.0": 60,
-      "2021.4.1": 30,
-      "2021.4.2": 20,
-      "2021.5.0b0": 100,
-      "2021.5.0": 20,
-      "2021.5.5": 30,
-      "2021.6.0.dev20210517": 8,
-      "2021.6.0.dev20210506": 11,
-      "2021.6.0": 100,
-      "2021.7.0.dev20210601": 7,
-    };
-    const versions = {
+    expect(groupVersions(sampleData)).toStrictEqual({
       "1970.1": 11,
       "2021.4": 110,
       "2021.5": 150,
       "2021.6": 119,
-    };
-
-    expect(groupVersions(data)).toStrictEqual(versions);
+    });
   });
 
   it("test production", function () {
     (global as any).WORKER_ENV = "production";
-    const data = {
-      "1970.1.0": 11,
-      "2021.4.0": 60,
-      "2021.4.1": 30,
-      "2021.4.2": 20,
-      "2021.5.0b0": 100,
-      "2021.5.0": 20,
-      "2021.5.5": 30,
-      "2021.6.0.dev20210517": 8,
-      "2021.6.0.dev20210506": 11,
-      "2021.6.0": 100,
-      "2021.7.0.dev20210601": 7,
-    };
-    const versions = {
+    expect(groupVersions(sampleData)).toStrictEqual({
       "2021.4": 110,
       "2021.5": 150,
       "2021.6": 119,
-    };
-
-    expect(groupVersions(data)).toStrictEqual(versions);
+    });
   });
 });


### PR DESCRIPTION
On dev we currently only have versions for 2021 (these were injected without TTL to ensure test data).
<https://dev--home-assistant-analytics.netlify.app/>

Using 10 for dev _should_ show more versions going forward.