### PR TITLE
Mark worker/package.json as private to stop action from complaining about missing fields

### DIFF
--- a/worker/package.json
+++ b/worker/package.json
@@ -1,3 +1,4 @@
 {
-  "main": "worker.js"
+  "main": "worker.js",
+  "private": true
 }


### PR DESCRIPTION
Ref <https://github.com/home-assistant/analytics.home-assistant.io/actions/runs/6454123508/job/17519010315?pr=782#step:6:10>