### PR TITLE
Change twitter:card from summary_large_image to summary

### DIFF
--- a/site/src/_layouts/base.html
+++ b/site/src/_layouts/base.html
@@ -34,7 +34,7 @@ navigation:
       property="og:image"
       content="https://brands.home-assistant.io/analytics/icon.png"
     />
-    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@home_assistant" />
     <meta name="twitter:title" content="Home Assistant Analytics" />
     <meta


### PR DESCRIPTION
Ideally we would have a large graphic to be used here and for `og:image`,
But for now lets just set this to "summary", which closes #639