### PR TITLE
Add event context and cf-ray to sentry

### DIFF
--- a/worker/src/handlers/post.ts
+++ b/worker/src/handlers/post.ts
@@ -21,8 +21,9 @@ export async function handlePostWrapper(
 ): Promise<Response> {
   try {
     return await handlePost(request, sentry);
-  } catch (e) {
-    sentry.captureException(e);
+  } catch (e: any) {
+    const captureId = sentry.captureException(e);
+    console.error(`${e?.message} (${captureId})`);
     return new Response(null, { status: 500 });
   }
 }
@@ -47,8 +48,9 @@ export async function handlePost(
   try {
     sentry.addBreadcrumb({ message: "Validate incoming payload" });
     incomingPayload = createIncomingPayload(request_json);
-  } catch (e) {
-    sentry.captureException(e);
+  } catch (e: any) {
+    const captureId = sentry.captureException(e);
+    console.error(`${e?.message} (${captureId})`);
     return new Response(null, { status: 400 });
   }
 

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -49,8 +49,9 @@ export async function handleSchedule(
     } else {
       throw new Error(`Unexpected schedule task: ${scheduledTask}`);
     }
-  } catch (e) {
-    sentry.captureException(e);
+  } catch (e: any) {
+    const captureId = sentry.captureException(e);
+    console.error(`${e?.message} (${captureId})`);
   }
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -13,10 +13,11 @@ const sentryClient = (event: FetchEvent | ScheduledEvent, handler: string) => {
   const client = new Toucan({
     dsn: SENTRY_DSN,
     requestDataOptions: {
-      allowedHeaders: ["user-agent"],
+      allowedHeaders: ["user-agent", "cf-ray"],
     },
     // request does not exist on ScheduledEvent
     request: "request" in event ? event.request : undefined,
+    context: event,
     environment: WORKER_ENV,
   });
   client.setTag("handler", handler);

--- a/worker/tests/handlers/post.spec.ts
+++ b/worker/tests/handlers/post.spec.ts
@@ -1,5 +1,5 @@
 import { handlePost } from "../../src/handlers/post";
-import { MockedKV, MockedSentry } from "../mock";
+import { MockedConsole, MockedKV, MockedSentry } from "../mock";
 
 class MockResponse {}
 
@@ -17,6 +17,7 @@ describe("post handler", function () {
   beforeEach(() => {
     MockSentry = MockedSentry();
     (global as any).KV = MockKV = MockedKV();
+    (global as any).console = MockedConsole();
     MockRequest = {
       json: async () => ({ ...BASE_PAYLOAD }),
       cf: { country: "XX" },

--- a/worker/tests/handlers/schedule.spec.ts
+++ b/worker/tests/handlers/schedule.spec.ts
@@ -10,7 +10,12 @@ import {
   SCHEMA_VERSION_QUEUE,
 } from "../../src/data";
 import { handleSchedule } from "../../src/handlers/schedule";
-import { MockedKV, MockedScheduledEvent, MockedSentry } from "../mock";
+import {
+  MockedConsole,
+  MockedKV,
+  MockedScheduledEvent,
+  MockedSentry,
+} from "../mock";
 
 describe("schedule handler", function () {
   let MockSentry;
@@ -20,6 +25,7 @@ describe("schedule handler", function () {
   beforeEach(() => {
     MockSentry = MockedSentry();
     (global as any).KV = MockKV = MockedKV();
+    (global as any).console = MockedConsole();
     (global as any).fetch = MockFetch = jest.fn(async () => ({
       ok: true,
       json: jest.fn(async () => ({

--- a/worker/tests/mock.ts
+++ b/worker/tests/mock.ts
@@ -5,6 +5,12 @@ export const MockedKV = () => ({
   getWithMetadata: jest.fn(async () => {}),
 });
 
+export const MockedConsole = () => ({
+  log: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
 export const MockedSentry = () => ({
   addBreadcrumb: jest.fn(),
   setUser: jest.fn(),


### PR DESCRIPTION
Before v3 of tucan-js the context was included in the event, when doing the migration I forgot about adding that back.

This PR also adds the `cf-ray` header.