### PR TITLE
Refactor worker entrypoint

### DIFF
--- a/worker/src/data.ts
+++ b/worker/src/data.ts
@@ -13,6 +13,26 @@ export const BRANDS_DOMAINS_URL =
   "https://brands.home-assistant.io/domains.json";
 export const VERSION_URL = "https://version.home-assistant.io/dev.json";
 
+export interface WorkerEnv {
+  KV: KVNamespace;
+  NETLIFY_BUILD_HOOK: string;
+  SENTRY_DSN: string;
+  WORKER_ENV: string;
+}
+
+export interface WorkerEvent {
+  env: WorkerEnv;
+  ctx: ExecutionContext;
+}
+
+export interface FetchWorkerEvent extends WorkerEvent {
+  request: CfRequest;
+}
+
+export interface ScheduledWorkerEvent extends WorkerEvent {
+  controller: ScheduledController;
+}
+
 export enum UuidMetadataKey {
   ADDED = "a",
   COUNTRY = "c",

--- a/worker/src/handlers/post.ts
+++ b/worker/src/handlers/post.ts
@@ -1,7 +1,7 @@
 // Receive data from a Home Assistant installation
 import { Toucan } from "toucan-js";
 import {
-  CfRequest,
+  FetchWorkerEvent,
   generateUuidMetadata,
   IncomingPayload,
   KV_PREFIX_UUID,
@@ -16,11 +16,11 @@ const expirationTtl = 5184000;
 const withRegion = new Set(["US"]);
 
 export async function handlePostWrapper(
-  request: CfRequest,
+  event: FetchWorkerEvent,
   sentry: Toucan
 ): Promise<Response> {
   try {
-    return await handlePost(request, sentry);
+    return await handlePost(event, sentry);
   } catch (e) {
     sentry.captureException(e);
     return new Response(null, { status: 500 });
@@ -28,9 +28,10 @@ export async function handlePostWrapper(
 }
 
 export async function handlePost(
-  request: CfRequest,
+  event: FetchWorkerEvent,
   sentry: Toucan
 ): Promise<Response> {
+  const { request } = event;
   let incomingPayload;
   sentry.addBreadcrumb({ message: "Process started" });
   const request_json = await request.json<Record<string, any>>();
@@ -62,11 +63,12 @@ export async function handlePost(
   const stored: {
     value?: IncomingPayload | null;
     metadata?: UuidMetadata | null;
-  } = await KV.getWithMetadata(storageKey, "json");
+  } = await event.env.KV.getWithMetadata(storageKey, "json");
 
   if (!stored || !stored.value) {
     sentry.addBreadcrumb({ message: "First contact for UUID, store payload" });
     await storePayload(
+      event,
       storageKey,
       incomingPayload,
       stringifiedPayload,
@@ -87,6 +89,7 @@ export async function handlePost(
   if (!deepEqual(stored.value, JSON.parse(stringifiedPayload))) {
     sentry.addBreadcrumb({ message: "Payload changed, update stored data" });
     await storePayload(
+      event,
       storageKey,
       incomingPayload,
       stringifiedPayload,
@@ -105,6 +108,7 @@ export async function handlePost(
     });
 
     await storePayload(
+      event,
       storageKey,
       incomingPayload,
       stringifiedPayload,
@@ -118,13 +122,14 @@ export async function handlePost(
 }
 
 async function storePayload(
+  event: FetchWorkerEvent,
   storageKey: string,
   payload: IncomingPayload,
   stringifiedPayload: string,
   currentTimestamp: number,
   metadata?: UuidMetadata | null
 ) {
-  await KV.put(storageKey, stringifiedPayload, {
+  await event.env.KV.put(storageKey, stringifiedPayload, {
     expirationTtl,
     metadata: generateUuidMetadata(payload, currentTimestamp, metadata),
   });

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -146,7 +146,7 @@ async function updateHistory(
     timestamp: timestampString,
     active_installations,
     installation_types: data.installation_types,
-    versions: groupVersions(data.versions),
+    versions: groupVersions(event, data.versions),
   });
 
   sentry.addBreadcrumb({ message: "Trigger Netlify build" });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,39 +1,45 @@
 import { Toucan } from "toucan-js";
 import { handlePostWrapper } from "./handlers/post";
 import { handleSchedule } from "./handlers/schedule";
+import { FetchWorkerEvent, ScheduledWorkerEvent } from "./data";
 
-declare global {
-  const KV: KVNamespace;
-  const NETLIFY_BUILD_HOOK: string;
-  const SENTRY_DSN: string;
-  const WORKER_ENV: string;
-}
-
-const sentryClient = (event: FetchEvent | ScheduledEvent, handler: string) => {
+const sentryClient = (
+  event: FetchWorkerEvent | ScheduledWorkerEvent,
+  handler: string
+) => {
   const client = new Toucan({
-    dsn: SENTRY_DSN,
+    dsn: event.env.SENTRY_DSN,
     requestDataOptions: {
       allowedHeaders: ["user-agent"],
     },
     // request does not exist on ScheduledEvent
     request: "request" in event ? event.request : undefined,
-    environment: WORKER_ENV,
+    environment: event.env.WORKER_ENV,
   });
   client.setTag("handler", handler);
 
   return client;
 };
 
-addEventListener("fetch", (event: FetchEvent) => {
-  if (event.request.method === "POST") {
-    event.respondWith(
-      handlePostWrapper(event.request, sentryClient(event, "post"))
-    );
-  } else {
-    event.respondWith(new Response(null, { status: 405 }));
-  }
-});
-
-addEventListener("scheduled", (event) => {
-  event.waitUntil(handleSchedule(event, sentryClient(event, "schedule")));
-});
+export default {
+  fetch: async (
+    request: FetchWorkerEvent["request"],
+    env: FetchWorkerEvent["env"],
+    ctx: FetchWorkerEvent["ctx"]
+  ) => {
+    const event: FetchWorkerEvent = { request, env, ctx };
+    if (request.method === "POST") {
+      return await handlePostWrapper(event, sentryClient(event, "post"));
+    } else {
+      return new Response(null, { status: 405 });
+    }
+  },
+  scheduled: async (
+    controller: ScheduledWorkerEvent["controller"],
+    env: ScheduledWorkerEvent["env"],
+    ctx: ScheduledWorkerEvent["ctx"]
+  ) => {
+    const event: ScheduledWorkerEvent = { controller, env, ctx };
+    await handleSchedule(event, sentryClient(event, "schedule"));
+  },
+} as ExportedHandler;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -16,8 +16,12 @@ const sentryClient = (
     request: "request" in event ? event.request : undefined,
     context: event.ctx,
     environment: event.env.WORKER_ENV,
+    initialScope: {
+      tags: {
+        handler,
+      },
+    },
   });
-  client.setTag("handler", handler);
 
   return client;
 };

--- a/worker/src/utils/group-versions.ts
+++ b/worker/src/utils/group-versions.ts
@@ -1,7 +1,12 @@
-export const groupVersions = (versions: Record<string, number>) => {
+import { WorkerEvent } from "../data";
+
+export const groupVersions = (
+  event: WorkerEvent,
+  versions: Record<string, number>
+) => {
   const releases: Record<string, number> = {};
   const releases_filtered: Record<string, number> = {};
-  const filterLowerLimit = WORKER_ENV === "dev" ? 10 : 100;
+  const filterLowerLimit = event.env.WORKER_ENV === "dev" ? 10 : 100;
 
   Object.keys(versions).forEach((version) => {
     const key: string = version.split(".").slice(0, 2).join(".");

--- a/worker/tests/handlers/schedule.spec.ts
+++ b/worker/tests/handlers/schedule.spec.ts
@@ -10,21 +10,14 @@ import {
   SCHEMA_VERSION_QUEUE,
 } from "../../src/data";
 import { handleSchedule } from "../../src/handlers/schedule";
-import {
-  MockedConsole,
-  MockedKV,
-  MockedScheduledEvent,
-  MockedSentry,
-} from "../mock";
+import { MockedConsole, MockedScheduledEvent, MockedSentry } from "../mock";
 
 describe("schedule handler", function () {
   let MockSentry;
-  let MockKV;
   let MockFetch;
 
   beforeEach(() => {
     MockSentry = MockedSentry();
-    (global as any).KV = MockKV = MockedKV();
     (global as any).console = MockedConsole();
     (global as any).fetch = MockFetch = jest.fn(async () => ({
       ok: true,
@@ -39,8 +32,8 @@ describe("schedule handler", function () {
   });
 
   describe("Unexpected task", function () {
-    const event: ScheduledEvent = MockedScheduledEvent({
-      cron: "test",
+    const event = MockedScheduledEvent({
+      controller: { cron: "test" },
     });
     it("Unexpected cron trigger", async () => {
       await handleSchedule(event, MockSentry);
@@ -51,31 +44,34 @@ describe("schedule handler", function () {
   });
 
   describe("RESET_QUEUE", function () {
-    const event: ScheduledEvent = MockedScheduledEvent({
-      cron: ScheduledTask.RESET_QUEUE,
-    });
     it("Not ready to reset", async () => {
-      MockKV.get = jest.fn(async () => ({
+      const event = MockedScheduledEvent({
+        controller: { cron: ScheduledTask.RESET_QUEUE },
+      });
+      (event.env.KV.get as jest.Mock).mockImplementation(async () => ({
         process_complete: false,
         entries: [],
       }));
 
       await handleSchedule(event, MockSentry);
 
-      expect(MockKV.get).toBeCalledWith(KV_KEY_QUEUE, "json");
+      expect(event.env.KV.get).toBeCalledWith(KV_KEY_QUEUE, "json");
       expect(MockSentry.setTag).toBeCalledWith("scheduled-task", "RESET_QUEUE");
-      expect(MockKV.put).toBeCalledTimes(0);
+      expect(event.env.KV.put).toBeCalledTimes(0);
     });
 
     it("Queue handing is done, reset queue", async () => {
-      MockKV.get = jest.fn(async () => ({
+      const event = MockedScheduledEvent({
+        controller: { cron: ScheduledTask.RESET_QUEUE },
+      });
+      (event.env.KV.get as jest.Mock).mockImplementation(async () => ({
         process_complete: true,
         entries: [],
       }));
 
       await handleSchedule(event, MockSentry);
-      expect(MockKV.put).toBeCalledTimes(1);
-      expect(MockKV.put).toBeCalledWith(
+      expect(event.env.KV.put).toBeCalledTimes(1);
+      expect(event.env.KV.put).toBeCalledWith(
         KV_KEY_QUEUE,
         JSON.stringify(createQueueDefaults())
       );
@@ -83,15 +79,14 @@ describe("schedule handler", function () {
   });
 
   describe("UPDATE_HISTORY", function () {
-    const event: ScheduledEvent = MockedScheduledEvent({
-      cron: ScheduledTask.UPDATE_HISTORY,
-    });
     it("With migration", async () => {
-      MockKV.get = jest.fn(async () => ({
+      const event = MockedScheduledEvent({
+        controller: { cron: ScheduledTask.UPDATE_HISTORY },
+      });
+      (event.env.KV.get as jest.Mock).mockImplementation(async () => ({
         "1234": { active_installations: 3 },
       }));
-
-      MockKV.list = jest.fn(async () => ({
+      (event.env.KV.list as jest.Mock).mockImplementation(async () => ({
         list_complete: true,
         keys: [
           { name: "uuid:1", metadata: { v: "2021.1.1", i: "o" } },
@@ -101,26 +96,29 @@ describe("schedule handler", function () {
 
       await handleSchedule(event, MockSentry);
 
-      expect(MockKV.get).toBeCalledWith(KV_KEY_CORE_ANALYTICS, "json");
+      expect(event.env.KV.get).toBeCalledWith(KV_KEY_CORE_ANALYTICS, "json");
       expect(MockSentry.setTag).toBeCalledWith(
         "scheduled-task",
         "UPDATE_HISTORY"
       );
-      expect(MockKV.put).toBeCalledTimes(1);
-      expect(MockKV.put).toBeCalledWith(
+      expect(event.env.KV.put).toBeCalledTimes(1);
+      expect(event.env.KV.put).toBeCalledWith(
         KV_KEY_CORE_ANALYTICS,
         expect.stringContaining('"extended_data_from":3')
       );
     });
 
     it("Update history and partial current", async () => {
-      MockKV.get = jest.fn(async () => ({
+      const event = MockedScheduledEvent({
+        controller: { cron: ScheduledTask.UPDATE_HISTORY },
+      });
+      (event.env.KV.get as jest.Mock).mockImplementation(async () => ({
         current: { extended_data_from: 3 },
         history: [],
         schema_version: SCHEMA_VERSION_ANALYTICS,
       }));
 
-      MockKV.list = jest.fn(async () => ({
+      (event.env.KV.list as jest.Mock).mockImplementation(async () => ({
         list_complete: true,
         keys: [
           { name: "uuid:1", metadata: { v: "2021.1.1", i: "o" } },
@@ -132,33 +130,39 @@ describe("schedule handler", function () {
 
       await handleSchedule(event, MockSentry);
 
-      expect(MockKV.get).toBeCalledWith(KV_KEY_CORE_ANALYTICS, "json");
+      expect(event.env.KV.get).toBeCalledWith(KV_KEY_CORE_ANALYTICS, "json");
       expect(MockSentry.setTag).toBeCalledWith(
         "scheduled-task",
         "UPDATE_HISTORY"
       );
-      expect(MockKV.put).toBeCalledTimes(1);
-      expect(MockKV.put).toBeCalledWith(
+
+      expect(event.env.KV.put).toBeCalledTimes(1);
+      expect(event.env.KV.put).toBeCalledWith(
         KV_KEY_CORE_ANALYTICS,
         expect.stringContaining('"extended_data_from":3')
       );
-      expect(MockKV.put).toBeCalledWith(
+      expect(event.env.KV.put).toBeCalledWith(
         KV_KEY_CORE_ANALYTICS,
         expect.stringContaining('"active_installations":4')
       );
     });
 
     it("Entries with missing metadata", async () => {
-      MockKV.get = jest.fn(async (key: string) => {
-        const KV_DATA = {
-          [KV_KEY_CORE_ANALYTICS]: { "1234": { active_installations: 3 } },
-          "uuid:1": { version: "123456" },
-        };
-
-        return KV_DATA[key];
+      const event = MockedScheduledEvent({
+        controller: { cron: ScheduledTask.UPDATE_HISTORY },
       });
+      (event.env.KV.get as jest.Mock).mockImplementation(
+        async (key: string) => {
+          const KV_DATA = {
+            [KV_KEY_CORE_ANALYTICS]: { "1234": { active_installations: 3 } },
+            "uuid:1": { version: "123456" },
+          };
 
-      MockKV.list = jest.fn(async () => ({
+          return KV_DATA[key];
+        }
+      );
+
+      (event.env.KV.list as jest.Mock).mockImplementation(async () => ({
         list_complete: true,
         keys: [
           { name: "uuid:1", expiration: 1234567 },
@@ -168,12 +172,12 @@ describe("schedule handler", function () {
 
       await handleSchedule(event, MockSentry);
       expect(MockFetch).not.toBeCalled();
-      expect(MockKV.get).toBeCalledWith(KV_KEY_CORE_ANALYTICS, "json");
+      expect(event.env.KV.get).toBeCalledWith(KV_KEY_CORE_ANALYTICS, "json");
       expect(MockSentry.setTag).toBeCalledWith(
         "scheduled-task",
         "UPDATE_HISTORY"
       );
-      expect(MockKV.put).toBeCalledWith(
+      expect(event.env.KV.put).toBeCalledWith(
         "uuid:1",
         expect.any(String),
         expect.objectContaining({
@@ -184,13 +188,15 @@ describe("schedule handler", function () {
   });
 
   describe("PROCESS_QUEUE", function () {
-    const event: ScheduledEvent = MockedScheduledEvent({
-      cron: ScheduledTask.PROCESS_QUEUE,
-    });
     it("No queue - list 2000 (with pagination)", async () => {
-      MockKV.get = jest.fn(async () => createQueueDefaults());
+      const event = MockedScheduledEvent({
+        controller: { cron: ScheduledTask.PROCESS_QUEUE },
+      });
+      (event.env.KV.get as jest.Mock).mockImplementation(async () =>
+        createQueueDefaults()
+      );
 
-      MockKV.list = jest.fn(
+      (event.env.KV.list as jest.Mock).mockImplementation(
         async (data: { prefix: string; cursor?: string }) => ({
           keys: Array.from({ length: 1000 }, (_, i) => ({ name: `uuid:${i}` })),
           cursor: "abc",
@@ -200,111 +206,128 @@ describe("schedule handler", function () {
 
       await handleSchedule(event, MockSentry);
 
-      expect(MockKV.get).toBeCalledWith(KV_KEY_QUEUE, "json");
-      expect(MockKV.list).toBeCalledTimes(2);
+      expect(event.env.KV.get).toBeCalledWith(KV_KEY_QUEUE, "json");
+      expect(event.env.KV.list).toBeCalledTimes(2);
       expect(MockSentry.setTag).toBeCalledWith(
         "scheduled-task",
         "PROCESS_QUEUE"
       );
 
-      expect(MockKV.put).toBeCalledWith(KV_KEY_QUEUE, expect.any(String));
-      expect(MockKV.put).toBeCalledTimes(1);
+      expect(event.env.KV.put).toBeCalledWith(KV_KEY_QUEUE, expect.any(String));
+      expect(event.env.KV.put).toBeCalledTimes(1);
     });
 
     it("Continue queue - 2000 entries left", async () => {
-      MockKV.get = jest.fn(async (key: string) => {
-        if (key === KV_KEY_QUEUE) {
-          return {
-            schema_version: SCHEMA_VERSION_QUEUE,
-            process_complete: false,
-            entries: Array.from({ length: 2000 }, (_, i) => ({
-              name: `uuid:${i}`,
-            })),
-            data: createQueueData(),
-          };
-        }
-
-        return {};
+      const event = MockedScheduledEvent({
+        controller: { cron: ScheduledTask.PROCESS_QUEUE },
       });
+      (event.env.KV.get as jest.Mock).mockImplementation(
+        async (key: string) => {
+          if (key === KV_KEY_QUEUE) {
+            return {
+              schema_version: SCHEMA_VERSION_QUEUE,
+              process_complete: false,
+              entries: Array.from({ length: 2000 }, (_, i) => ({
+                name: `uuid:${i}`,
+              })),
+              data: createQueueData(),
+            };
+          }
+
+          return {};
+        }
+      );
 
       await handleSchedule(event, MockSentry);
 
-      expect(MockKV.get).toBeCalledWith(KV_KEY_QUEUE, "json");
-      expect(MockKV.list).not.toBeCalled();
+      expect(event.env.KV.get).toBeCalledWith(KV_KEY_QUEUE, "json");
+      expect(event.env.KV.list).not.toBeCalled();
       expect(MockSentry.setTag).toBeCalledWith(
         "scheduled-task",
         "PROCESS_QUEUE"
       );
 
-      expect(MockKV.put).toBeCalledWith(
+      expect(event.env.KV.put).toBeCalledWith(
         KV_KEY_QUEUE,
         expect.stringContaining('"process_complete":false')
       );
-      expect(MockKV.put).toBeCalledTimes(1);
+      expect(event.env.KV.put).toBeCalledTimes(1);
     });
 
     it("Continue queue - 500 entries left", async () => {
-      MockKV.get = jest.fn(async (key: string) => {
-        if (key === KV_KEY_QUEUE) {
+      const event = MockedScheduledEvent({
+        controller: { cron: ScheduledTask.PROCESS_QUEUE },
+      });
+      (event.env.KV.get as jest.Mock).mockImplementation(
+        async (key: string) => {
+          if (key === KV_KEY_QUEUE) {
+            return {
+              schema_version: SCHEMA_VERSION_QUEUE,
+              process_complete: false,
+              entries: Array.from({ length: 500 }, (_, i) => ({
+                name: `uuid:${i}`,
+              })),
+              data: createQueueData(),
+            };
+          }
+
           return {
-            schema_version: SCHEMA_VERSION_QUEUE,
-            process_complete: false,
-            entries: Array.from({ length: 500 }, (_, i) => ({
-              name: `uuid:${i}`,
-            })),
-            data: createQueueData(),
+            integrations: ["core_valid"],
+            custom_integrations: [
+              { domain: "custom_invalid", version: "1.2.3" },
+              { domain: "custom_valid", version: "1.2.3" },
+            ],
+            operating_system: {
+              board: "invalid_board",
+              version: "1.2.3",
+            },
           };
         }
-
-        return {
-          integrations: ["core_valid"],
-          custom_integrations: [
-            { domain: "custom_invalid", version: "1.2.3" },
-            { domain: "custom_valid", version: "1.2.3" },
-          ],
-          operating_system: {
-            board: "invalid_board",
-            version: "1.2.3",
-          },
-        };
-      });
+      );
 
       await handleSchedule(event, MockSentry);
 
-      expect(MockKV.get).toBeCalledWith(KV_KEY_QUEUE, "json");
-      expect(MockKV.list).not.toBeCalled();
+      expect(event.env.KV.get).toBeCalledWith(KV_KEY_QUEUE, "json");
+      expect(event.env.KV.list).not.toBeCalled();
       expect(MockSentry.setTag).toBeCalledWith(
         "scheduled-task",
         "PROCESS_QUEUE"
       );
 
-      expect(MockKV.put).toBeCalledWith(
+      expect(event.env.KV.put).toBeCalledWith(
         KV_KEY_QUEUE,
         expect.stringContaining('"process_complete":true')
       );
-      expect(MockKV.put).toBeCalledWith(
+      expect(event.env.KV.put).toBeCalledWith(
         KV_KEY_CORE_ANALYTICS,
         expect.stringContaining("core_valid")
       );
-      expect(MockKV.put).toBeCalledWith(
+      expect(event.env.KV.put).toBeCalledWith(
         KV_KEY_CORE_ANALYTICS,
         expect.not.stringContaining("invalid_board")
       );
-      expect(MockKV.put).toBeCalledWith(KV_KEY_ADDONS, expect.any(String));
-      expect(MockKV.put).toBeCalledWith(
+      expect(event.env.KV.put).toBeCalledWith(
+        KV_KEY_ADDONS,
+        expect.any(String)
+      );
+      expect(event.env.KV.put).toBeCalledWith(
         KV_KEY_CUSTOM_INTEGRATIONS,
         '{"custom_valid":{"total":500,"versions":{"1.2.3":500}}}'
       );
-      expect(MockKV.put).toBeCalledWith(
+      expect(event.env.KV.put).toBeCalledWith(
         expect.stringContaining("history:"),
         expect.any(String)
       );
       expect(MockFetch).toBeCalledTimes(3);
-      expect(MockKV.put).toBeCalledTimes(5);
+      expect(event.env.KV.put).toBeCalledTimes(5);
     });
 
     it("Wait for reset", async () => {
-      MockKV.get = jest.fn(async () => ({
+      const event = MockedScheduledEvent({
+        controller: { cron: ScheduledTask.PROCESS_QUEUE },
+      });
+
+      (event.env.KV.get as jest.Mock).mockImplementation(async () => ({
         entries: [],
         process_complete: true,
         schema_version: SCHEMA_VERSION_QUEUE,
@@ -312,14 +335,14 @@ describe("schedule handler", function () {
 
       await handleSchedule(event, MockSentry);
 
-      expect(MockKV.get).toBeCalledWith(KV_KEY_QUEUE, "json");
+      expect(event.env.KV.get).toBeCalledWith(KV_KEY_QUEUE, "json");
       expect(MockSentry.setTag).toBeCalledWith(
         "scheduled-task",
         "PROCESS_QUEUE"
       );
 
-      expect(MockKV.put).not.toBeCalled();
-      expect(MockKV.list).not.toBeCalled();
+      expect(event.env.KV.put).not.toBeCalled();
+      expect(event.env.KV.list).not.toBeCalled();
 
       expect(MockSentry.addBreadcrumb).toBeCalledWith({
         message: "Process complete, waiting for reset",

--- a/worker/tests/mock.ts
+++ b/worker/tests/mock.ts
@@ -1,9 +1,13 @@
-export const MockedKV = () => ({
-  put: jest.fn(async () => {}),
-  get: jest.fn(async () => {}),
-  list: jest.fn(async () => {}),
-  getWithMetadata: jest.fn(async () => {}),
-});
+import { ScheduledWorkerEvent, FetchWorkerEvent } from "../src/data";
+
+export const MockedKV = () =>
+  ({
+    put: jest.fn(async () => {}),
+    get: jest.fn(async () => ""),
+    list: jest.fn(async () => {}),
+    delete: jest.fn(async () => {}),
+    getWithMetadata: jest.fn(async () => {}),
+  } as unknown as KVNamespace);
 
 export const MockedConsole = () => ({
   log: jest.fn(),
@@ -21,28 +25,64 @@ export const MockedSentry = () => ({
   captureMessage: jest.fn(),
 });
 
-export const MockedScheduledEvent = (options: any): ScheduledEvent => ({
-  type: "cron",
-  eventPhase: 0,
-  composed: true,
-  bubbles: true,
-  cancelable: true,
-  defaultPrevented: false,
-  returnValue: false,
-  timeStamp: 0,
-  isTrusted: true,
-  cancelBubble: false,
-  stopImmediatePropagation: () => ({}),
-  preventDefault: () => ({}),
-  stopPropagation: () => ({}),
-  composedPath: () => [],
-  NONE: 0,
-  CAPTURING_PHASE: 0,
-  AT_TARGET: 0,
-  BUBBLING_PHASE: 0,
-  cron: "",
-  scheduledTime: 0,
-  noRetry: () => ({}),
-  waitUntil: async (promise: Promise<any>) => ({}),
-  ...options,
+export const BASE_PAYLOAD = {
+  uuid: "12345678901234567890123456789012",
+  installation_type: "Unknown",
+  version: "1970.1.1",
+};
+
+export const MockedFetchEvent = (options: {
+  request?: Partial<FetchWorkerEvent["request"]>;
+  env?: Partial<FetchWorkerEvent["env"]>;
+  ctx?: Partial<FetchWorkerEvent["ctx"]>;
+  payload?: Record<string, any>;
+}): FetchWorkerEvent => ({
+  request: {
+    cf: {
+      country: "XX",
+      ...options.request?.cf,
+    } as IncomingRequestCfProperties,
+    json: async () => ({
+      ...BASE_PAYLOAD,
+      ...options.payload,
+    }),
+    ...options.request,
+  } as FetchWorkerEvent["request"],
+  env: {
+    SENTRY_DSN: "",
+    WORKER_ENV: "testing",
+    NETLIFY_BUILD_HOOK: "https://somesite/hook",
+    KV: MockedKV(),
+    ...options.env,
+  },
+  ctx: {
+    waitUntil: () => {},
+    passThroughOnException: () => {},
+    ...options.ctx,
+  },
+});
+
+export const MockedScheduledEvent = (options: {
+  controller?: Partial<ScheduledWorkerEvent["controller"]>;
+  env?: Partial<ScheduledWorkerEvent["env"]>;
+  ctx?: Partial<ScheduledWorkerEvent["ctx"]>;
+}): ScheduledWorkerEvent => ({
+  controller: {
+    scheduledTime: 1234,
+    cron: "",
+    noRetry: () => {},
+    ...options.controller,
+  },
+  env: {
+    SENTRY_DSN: "",
+    WORKER_ENV: "testing",
+    NETLIFY_BUILD_HOOK: "https://somesite/hook",
+    KV: MockedKV(),
+    ...options.env,
+  },
+  ctx: {
+    waitUntil: () => {},
+    passThroughOnException: () => {},
+    ...options.ctx,
+  },
 });

--- a/worker/tests/utils/group-versions.spec.ts
+++ b/worker/tests/utils/group-versions.spec.ts
@@ -1,4 +1,5 @@
 import { groupVersions } from "../../src/utils/group-versions";
+import { MockedScheduledEvent } from "../mock";
 
 const sampleData = {
   "1970.1.0": 11,
@@ -20,8 +21,9 @@ describe("groupVersions", function () {
   });
 
   it("test dev", function () {
-    (global as any).WORKER_ENV = "dev";
-    expect(groupVersions(sampleData)).toStrictEqual({
+    const event = MockedScheduledEvent({ env: { WORKER_ENV: "dev" } });
+
+    expect(groupVersions(event, sampleData)).toStrictEqual({
       "1970.1": 11,
       "2021.4": 110,
       "2021.5": 150,
@@ -30,8 +32,8 @@ describe("groupVersions", function () {
   });
 
   it("test production", function () {
-    (global as any).WORKER_ENV = "production";
-    expect(groupVersions(sampleData)).toStrictEqual({
+    const event = MockedScheduledEvent({ env: { WORKER_ENV: "production" } });
+    expect(groupVersions(event, sampleData)).toStrictEqual({
       "2021.4": 110,
       "2021.5": 150,
       "2021.6": 119,


### PR DESCRIPTION
A while back Cloudflare changed how workers should be defined from the old style event listener to the new exported handler.

This PR migrates the worker in this repository to the new style.