### PR TITLE
Add Cloudflared Add-On

### DIFF
--- a/site/src/add-ons.html
+++ b/site/src/add-ons.html
@@ -218,6 +218,10 @@ addons_details:
     name: ESPHome (dev)
     documentation: https://github.com/esphome/home-assistant-addon/blob/main/esphome-dev/DOCS.md
     icon: https://raw.githubusercontent.com/esphome/home-assistant-addon/main/esphome-dev/icon.png
+  9074a9fa_cloudflared:
+    name: Cloudflared
+    documentation: https://github.com/brenner-tobias/ha-addons/blob/main/cloudflared/DOCS.md
+    icon: https://raw.githubusercontent.com/brenner-tobias/ha-addons/main/cloudflared/icon.png
 ---
 
 <script>


### PR DESCRIPTION
Add the widely used [Add-On Cloudflared](https://github.com/brenner-tobias/addon-cloudflared).

The Add-on can be found in the [analytics JSON for add-ons](https://analytics.home-assistant.io/addons.json) (9074a9fa_cloudflared).