### PR TITLE
Move site generation to a separate schedule

### DIFF
--- a/worker/src/data.ts
+++ b/worker/src/data.ts
@@ -62,6 +62,7 @@ export enum ScheduledTask {
   PROCESS_QUEUE = "*/2 * * * *",
   RESET_QUEUE = "5 0 * * *",
   UPDATE_HISTORY = "0 * * * *",
+  REGENERATE_SITE = "15 * * * *",
 }
 
 export interface UuidMetadata {

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -4,7 +4,7 @@ main = "./src/index.ts"
 send_metrics = false
 
 [triggers]
-crons = ["*/2 * * * *", "5 0 * * *", "0 * * * *"]
+crons = ["*/2 * * * *", "5 0 * * *", "0 * * * *", "15 * * * *"]
 
 # For production environment, use '-e production'
 [env.production]


### PR DESCRIPTION
We are sometimes hitting CPU limits, I think that is related to the time it can take when trigger the site build.
So as an attempt to mitigate the problem, that part has been extracted to its own schedule.