### PR TITLE
Add Odroid-M1S to board names

### DIFF
--- a/site/src/tools/friendly_names.js
+++ b/site/src/tools/friendly_names.js
@@ -7,6 +7,7 @@ const HaOsBoard = {
   "odroid-c2": "ODROID-C2",
   "odroid-c4": "ODROID-C4",
   "odroid-m1": "ODROID-M1",
+  "odroid-m1s": "ODROID-M1S",
   "odroid-n2": "ODROID-N2",
   "odroid-xu4": "ODROID-XU4",
   rpi: "Raspberry Pi",


### PR DESCRIPTION
New board for HAOS 12.0
https://github.com/home-assistant/operating-system/releases/tag/12.0.rc1