### PR TITLE
Add an introduction to analytics website

### DIFF
--- a/site/src/index.html
+++ b/site/src/index.html
@@ -10,6 +10,16 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
 ---
 
 <style>
+  .intro {
+    display: flex;
+    flex-direction: row;
+    column-gap: 3em;
+    row-gap: 1em;
+    margin-bottom: 1em;
+  }
+  .intro > * {
+    flex: 1;
+  }
   .chart-title {
     color: var(--secondary-text-color);
   }
@@ -23,12 +33,30 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
     flex: 1;
     margin: 0 16px;
   }
+  @media only screen and (max-width: 800px) {
+    .intro {
+      flex-direction: column;
+    }
+  }
   @media only screen and (max-width: 600px) {
     .half {
       flex-direction: column-reverse;
     }
   }
 </style>
+
+<div class="intro">
+  <div>
+    Home Assistant allows users to share their usage data. It is used to
+    influence Home Assistant development priorities and to convince
+    manufacturers to add local control and privacy-focused features.
+  </div>
+  <div>
+    Analytics in Home Assistant are opt-in and do not reflect the entire Home
+    Assistant userbase. We estimate that a third of all Home Assistant users opt
+    in.
+  </div>
+</div>
 
 <div class="chart-title">
   {{ data.history.last.active_installations | formatNumber }} Active Home


### PR DESCRIPTION
This adds a small (responsive) introduction to the analytics website.

<img width="1053" alt="image" src="https://github.com/home-assistant/analytics.home-assistant.io/assets/1444314/2f5aef19-f996-4cff-9427-2d1b6f247184">
