### PR TITLE
Add "endpoints" with prometheus compatible metrics

### DIFF
--- a/site/src/prometheus/addons.liquid
+++ b/site/src/prometheus/addons.liquid
@@ -1,6 +1,7 @@
 ---
 # This file is used to generate the prometheus/addons endpoint
 permalink: '/prometheus/addons'
+eleventyAllowMissingExtension: true
 ---
 #
 # Example usage:

--- a/site/src/prometheus/addons.liquid
+++ b/site/src/prometheus/addons.liquid
@@ -1,0 +1,22 @@
+---
+# This file is used to generate the prometheus/addons endpoint
+permalink: '/prometheus/addons'
+---
+#
+# Example usage:
+#  - job_name: "homeassistant_analytics_addons"
+#    scrape_interval: 1h
+#    metrics_path: /prometheus/addons
+#    scheme: https
+#    static_configs:
+#      - targets: ["analytics.home-assistant.io"]
+#
+
+{%- for addon in addons %}
+addon_total{slug="{{addon[0]}}"} {{addon[1]["total"]}}
+addon_auto_update{slug="{{addon[0]}}"} {{addon[1]["auto_update"]}}
+addon_protected{slug="{{addon[0]}}"} {{addon[1]["protected"]}}
+{%- for version in addon[1]["versions"] %}
+addon_version{slug="{{addon[0]}}",version="{{version[0]}}"} {{version[1]}}
+{%- endfor %}
+{%- endfor -%}

--- a/site/src/prometheus/base.liquid
+++ b/site/src/prometheus/base.liquid
@@ -1,6 +1,7 @@
 ---
 # This file is used to generate the prometheus/base endpoint
 permalink: '/prometheus/base'
+eleventyAllowMissingExtension: true
 ---
 #
 # Example usage:

--- a/site/src/prometheus/base.liquid
+++ b/site/src/prometheus/base.liquid
@@ -1,0 +1,48 @@
+---
+# This file is used to generate the prometheus/base endpoint
+permalink: '/prometheus/base'
+---
+#
+# Example usage:
+#  - job_name: "homeassistant_analytics_base"
+#    scrape_interval: 1h
+#    metrics_path: /prometheus/base
+#    scheme: https
+#    static_configs:
+#      - targets: ["analytics.home-assistant.io"]
+#
+instances {{ data.history.last.active_installations }}
+{%- for installation_types in data.current.installation_types %}
+installation_type{type="{{ installation_types[0] }}"} {{ installation_types[1] }}
+{%- endfor %}
+
+reports_addons {{ data.current.reports_addons }}
+reports_integrations {{ data.current.reports_integrations }}
+reports_statistics {{ data.current.reports_statistics }}
+
+median_addons_count {{ data.current.avg_addons }}
+median_automations_count {{ data.current.avg_automations }}
+median_integrations_count {{ data.current.avg_integrations }}
+median_states_count {{ data.current.avg_states }}
+median_users_count {{ data.current.avg_users }}
+
+{% for country in data.current.countries %}
+country{code="{{ country[0] }}"} {{ country[1] }}
+{%- endfor %}
+
+{% for version in data.current.versions %}
+version{version="{{ version[0] }}"} {{ version[1] }}
+{%- endfor %}
+
+supervisor_unhealthy {{ data.current.supervisor["unhealthy"] }}
+supervisor_unsupported {{ data.current.supervisor["unsupported"] }}
+{% for arch in data.current.supervisor["arch"] %}
+supervisor_arch{arch="{{ arch[0] }}"} {{ arch[1] }}
+{%- endfor %}
+
+{% for board in data.current.operating_system["boards"] %}
+operating_system_board{board="{{ board[0] }}"} {{ board[1] }}
+{%- endfor %}
+{% for version in data.current.operating_system["versions"] %}
+operating_system_version{version="{{ version[0] }}"} {{ version[1] }}
+{%- endfor %}

--- a/site/src/prometheus/custom_integrations.liquid
+++ b/site/src/prometheus/custom_integrations.liquid
@@ -1,6 +1,7 @@
 ---
 # This file is used to generate the prometheus/custom_integrations endpoint
 permalink: '/prometheus/custom_integrations'
+eleventyAllowMissingExtension: true
 ---
 #
 # Example usage:

--- a/site/src/prometheus/custom_integrations.liquid
+++ b/site/src/prometheus/custom_integrations.liquid
@@ -1,0 +1,20 @@
+---
+# This file is used to generate the prometheus/custom_integrations endpoint
+permalink: '/prometheus/custom_integrations'
+---
+#
+# Example usage:
+#  - job_name: "homeassistant_analytics_custom_integrations"
+#    scrape_interval: 1h
+#    metrics_path: /prometheus/custom_integrations
+#    scheme: https
+#    static_configs:
+#      - targets: ["analytics.home-assistant.io"]
+#
+
+{%- for integration in custom_integrations %}
+custom_integration{domain="{{ integration[0] }}"} {{ integration[1]["total"] }}
+{%- for version in integration[1]["versions"] %}
+custom_integration_version{domain="{{ integration[0] }}",version="{{version[0]}}"} {{ version[1] }}
+{%- endfor -%}
+{%- endfor -%}

--- a/site/src/prometheus/integrations.liquid
+++ b/site/src/prometheus/integrations.liquid
@@ -1,6 +1,7 @@
 ---
 # This file is used to generate the prometheus/integrations endpoint
 permalink: '/prometheus/integrations'
+eleventyAllowMissingExtension: true
 ---
 #
 # Example usage:

--- a/site/src/prometheus/integrations.liquid
+++ b/site/src/prometheus/integrations.liquid
@@ -1,0 +1,17 @@
+---
+# This file is used to generate the prometheus/integrations endpoint
+permalink: '/prometheus/integrations'
+---
+#
+# Example usage:
+#  - job_name: "homeassistant_analytics_integrations"
+#    scrape_interval: 1h
+#    metrics_path: /prometheus/integrations
+#    scheme: https
+#    static_configs:
+#      - targets: ["analytics.home-assistant.io"]
+#
+
+{%- for integration in data.current.integrations %}
+integration{domain="{{ integration[0] }}"} {{ integration[1] }}
+{%- endfor -%}


### PR DESCRIPTION
These "endpoints" can be used for the Prometheus scraper and graphed directly or in tools like Grafana.
![image](https://github.com/user-attachments/assets/cdceb5fd-15c7-4e2f-8c2d-b17aba1a5116)


Im not really sure how useful this is, personally, I want this data, but I could also run a Prometheus exporter locally with this.