### PR TITLE
Add Assist Microphone to core add-ons list

### DIFF
--- a/site/src/add-ons.html
+++ b/site/src/add-ons.html
@@ -6,6 +6,8 @@ addons_details:
     name: Ada
   core_almond:
     name: Almond
+  core_assist_microphone:
+    name: Assist Microphone
   core_cec_scan:
     name: CEC Scanner
   core_configurator:


### PR DESCRIPTION
Assist Microphone has been added to the core add-ons, so I thought I'd add it to the analytics view as well. 