### PR TITLE
Add permissions to workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,8 @@ on:
       - main
       - dev
 
+permissions: {}
+
 jobs:
   worker:
     runs-on: ubuntu-latest

--- a/.github/workflows/worker.yaml
+++ b/.github/workflows/worker.yaml
@@ -6,6 +6,8 @@ on:
       - main
       - dev
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
So, while we can have the same outcome by changing the repository setting for it, as read is now applied to all workflows.
That setting does not apply to forks.