### PR TITLE
forth -> less than a fourth

### DIFF
--- a/site/src/index.html
+++ b/site/src/index.html
@@ -54,7 +54,7 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
   <div>
     Analytics in Home Assistant are opt-in and do not reflect the entire Home
     Assistant userbase. We estimate that less than a fourth of all Home Assistant
-    users opt in to share their usage data for this quantitative data analysis.
+    users opt in.
   </div>
 </div>
 

--- a/site/src/index.html
+++ b/site/src/index.html
@@ -53,8 +53,8 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
   </div>
   <div>
     Analytics in Home Assistant are opt-in and do not reflect the entire Home
-    Assistant userbase. We estimate that a fourth of all Home Assistant users opt
-    in.
+    Assistant userbase. We estimate that less than a fourth of all Home Assistant
+    users opt in to share their usage data for this quantitative data analysis.
   </div>
 </div>
 


### PR DESCRIPTION
Related to https://github.com/home-assistant/analytics.home-assistant.io/pull/964 PR by @balloob 

Changed "_a fourth_" to intead say "_**less than less than a fourth**_" to make the "2-million" estimate hold true -> https://www.home-assistant.io/blog/2025/04/16/state-of-the-open-home-recap/ 

At least based on based on current analytics which at this date "only" lists 478,363 Active Home Assistant Installations so does not quite make 2-million as of yet -> https://analytics.home-assistant.io