### PR TITLE
Track OS version per board

### DIFF
--- a/site/src/prometheus/base.liquid
+++ b/site/src/prometheus/base.liquid
@@ -47,3 +47,8 @@ operating_system_board{board="{{ board[0] }}"} {{ board[1] }}
 {% for version in data.current.operating_system["versions"] %}
 operating_system_version{version="{{ version[0] }}"} {{ version[1] }}
 {%- endfor %}
+{% for board in data.current.operating_system["board_versions"] %}
+{%- for version in board[1] %}
+operating_system_board_version{board="{{ board[0] }}",version="{{ version[0] }}"} {{ version[1] }}
+{%- endfor %}
+{%- endfor %}

--- a/worker/src/data.ts
+++ b/worker/src/data.ts
@@ -6,8 +6,8 @@ export const KV_PREFIX_HISTORY = "history";
 export const KV_PREFIX_UUID = "uuid";
 export const KV_MAX_PROCESS_ENTRIES = 800;
 
-export const SCHEMA_VERSION_QUEUE = 14;
-export const SCHEMA_VERSION_ANALYTICS = 3;
+export const SCHEMA_VERSION_QUEUE = 15;
+export const SCHEMA_VERSION_ANALYTICS = 4;
 
 export const BRANDS_DOMAINS_URL =
   "https://brands.home-assistant.io/domains.json";
@@ -125,6 +125,7 @@ export interface QueueData {
   operating_system: {
     boards: Record<string, number>;
     versions: Record<string, number>;
+    board_versions: Record<string, Record<string, number>>;
   };
   integrations: Record<string, number>;
   count_addons: number[];
@@ -185,6 +186,7 @@ export interface AnalyticsDataCurrent {
   operating_system: {
     versions: Record<string, number>;
     boards: Record<string, number>;
+    board_versions: Record<string, Record<string, number>>;
   };
   installation_types: {
     os: number;
@@ -254,7 +256,7 @@ export const createQueueData = (): QueueData => ({
   reports_addons: 0,
   versions: {},
   countries: {},
-  operating_system: { boards: {}, versions: {} },
+  operating_system: { boards: {}, versions: {}, board_versions: {} },
   supervisor: {
     arch: {},
     unhealthy: 0,

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -416,15 +416,21 @@ function combineEntryData(
 
   if (entrydata.operating_system) {
     if (osBoards.has(entrydata.operating_system.board)) {
-      data.operating_system.boards[entrydata.operating_system.board] =
-        bumpValue(
-          data.operating_system.boards[entrydata.operating_system.board]
-        );
+      const board = entrydata.operating_system.board;
+      data.operating_system.boards[board] =
+        bumpValue(data.operating_system.boards[board]);
+
       if (entrydata.operating_system.version) {
-        data.operating_system.versions[entrydata.operating_system.version] =
-          bumpValue(
-            data.operating_system.versions[entrydata.operating_system.version]
-          );
+        const version = entrydata.operating_system.version;
+        data.operating_system.versions[version] =
+          bumpValue(data.operating_system.versions[version]);
+
+        // Track OS version per board
+        if (!data.operating_system.board_versions[board]) {
+          data.operating_system.board_versions[board] = {};
+        }
+        data.operating_system.board_versions[board][version] =
+          bumpValue(data.operating_system.board_versions[board][version]);
       }
     }
   }

--- a/worker/src/utils/migrate.ts
+++ b/worker/src/utils/migrate.ts
@@ -24,7 +24,7 @@ export const migrateAnalyticsData = (data: any): AnalyticsData => {
       reports_statistics: 0,
       extended_data_from: 0,
       versions: {},
-      operating_system: { boards: {}, versions: {} },
+      operating_system: { boards: {}, versions: {}, board_versions: {} },
       installation_types: {
         os: 0,
         container: 0,
@@ -69,6 +69,17 @@ export const migrateAnalyticsData = (data: any): AnalyticsData => {
   if (data.schema_version < 3) {
     analyticsData.current = { ...analyticsData.current, ...data.current };
     analyticsData.history = data.history;
+  }
+
+  // Handle migration from schema version 3 to 4 (add board_versions)
+  if (data.schema_version === 3) {
+    analyticsData.current = { ...analyticsData.current, ...data.current };
+    analyticsData.history = data.history;
+
+    // Initialize board_versions if not present
+    if (!analyticsData.current.operating_system.board_versions) {
+      analyticsData.current.operating_system.board_versions = {};
+    }
   }
 
   return analyticsData;


### PR DESCRIPTION
This adds OS version per board to the backend data. No frontend for this data as this information is mainly useful for developers.