### PR TITLE
fix: Installations graphs responsiveness

### DIFF
--- a/site/src/_static/chartjs-html-legend-plugin.js
+++ b/site/src/_static/chartjs-html-legend-plugin.js
@@ -1,0 +1,111 @@
+const getOrCreateLegendList = (chart, layout) => {
+  const legendContainer = chart.canvas.parentElement.querySelector(`.chart__legend`);
+  if (!legendContainer) {
+    throw new Error(`No legend container found`);
+  }
+
+  let listContainer = legendContainer.querySelector("div.chart__legend__container");
+  if (!listContainer) {
+    listContainer = document.createElement("div");
+    listContainer.classList.add("chart__legend__container");
+    if (layout === 'COLUMN') {
+      listContainer.classList.add("chart__legend__container--column");
+    }
+
+    legendContainer.append(listContainer);
+  }
+
+  return listContainer;
+};
+
+const chartJsHtmlLegendPlugin = {
+  id: "htmlLegend",
+  afterUpdate(chart, arguments_) {
+    if (arguments_.mode === "resize") {
+      return;
+    }
+    const chartType = chart.config.type;
+    const layout =
+      chartType === "bar" || chartType === "line"
+        ? 'ROW'
+        : 'COLUMN';
+    const container = getOrCreateLegendList(chart, layout);
+
+    // Remove old legend items
+    while (container.firstChild) {
+      container.firstChild.remove();
+    }
+
+    const items = chart.legend.legendItems;
+    for (const item of items) {
+      const button = document.createElement("div");
+      button.classList.add("chart__legend__button");
+      button.addEventListener("click", () => {
+        if (chartType === "pie" || chartType === "doughnut") {
+          // Pie and doughnut charts only have a single dataset and visibility is per item
+          chart.toggleDataVisibility(item.index);
+        } else {
+          chart.setDatasetVisibility(
+            item.datasetIndex,
+            !chart.isDatasetVisible(item.datasetIndex),
+          );
+        }
+        chart.update();
+      });
+
+      // Color
+      const colorSpan = document.createElement("span");
+      colorSpan.classList.add("chart__legend__color");
+      colorSpan.style.background = item.fillStyle;
+      colorSpan.style.borderColor = item.strokeStyle;
+      colorSpan.style.borderWidth = item.lineWidth + "px";
+      button.append(colorSpan);
+
+      // Text
+      const textContainer = document.createElement("span");
+      textContainer.classList.add("chart__legend__text");
+      textContainer.style.textDecoration = item.hidden ? "line-through" : "";
+      const labelNode = document.createTextNode(item.text);
+      button.append(textContainer);
+
+      const dataset = chart.data.datasets[item.datasetIndex || 0];
+      if (chartType === "pie" || chartType === "doughnut") {
+        const sum = dataset.data.reduce((accumulator, value) => accumulator + value, 0);
+        const current = dataset.data[item.index];
+        const boldNumberContainer = document.createElement("strong");
+        boldNumberContainer.classList.add(
+          "chart__legend__text",
+          "chart__legend__text--bold",
+        );
+        const numberNode = document.createTextNode(current.toLocaleString());
+        let percentNode = undefined;
+
+        if (sum && current) {
+          const percented = (100 * current / sum).toFixed(2);
+          percentNode = document.createTextNode(`(${percented} %)`);
+        }
+
+        textContainer.append(labelNode);
+        boldNumberContainer.append(numberNode);
+        button.append(boldNumberContainer);
+
+        if (percentNode) {
+          const boldPercentContainer = document.createElement("strong");
+          boldPercentContainer.classList.add(
+            "chart__legend__text",
+            "chart__legend__text--bold",
+            "chart__legend__text--percent",
+          );
+          boldPercentContainer.append(percentNode);
+          button.append(boldPercentContainer);
+        }
+      } else {
+        textContainer.append(labelNode);
+      }
+
+      container.append(button);
+    }
+  },
+};
+
+window.chartJsHtmlLegendPlugin = chartJsHtmlLegendPlugin;

--- a/site/src/index.html
+++ b/site/src/index.html
@@ -6,6 +6,7 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
   <script src="/static/svgMap.min.js"></script>
   <script src="/static/chart.umd.js"></script>
   <script src="/static/chartjs-adapter-date-fns.bundle.min.js"></script>
+  <script src="/static/chartjs-html-legend-plugin.js"></script>
   <link href="/static/svgMap.min.css" rel="stylesheet">
 ---
 
@@ -18,21 +19,90 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
   .col {
     flex: 1 0 0;
   }
-  .chart-title {
+  .chart {
+    --chart-spacing: 8px;
+
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--chart-spacing);
+  }
+  .chart--pie {
+    flex-direction: row;
+  }
+  .chart__title {
     color: var(--secondary-text-color);
     margin-bottom: 0.5rem;
   }
-  canvas {
-    width: 100%;
+  .chart__canvas {
+    width: 100% !important; /* !important to be stringer that inline styling added by Chart.js */
   }
-  @media only screen and (max-width: 600px) {
-    .row {
+  .chart--pie .chart__canvas {
+    width: 50% !important; /* !important to be stringer that inline styling added by Chart.js */
+    height: auto !important; /* !important to be stringer that inline styling added by Chart.js */
+  }
+  .chart__legend {
+    color: var(--secondary-text-color);
+  }
+  .chart__legend__container {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: var(--chart-spacing);
+  }
+  @media only screen and (min-width: 600px) {
+    .chart__legend__container--column {
       flex-direction: column;
     }
-
-    .row-donut {
+  }
+  .chart__legend__button {
+    display: flex;
+    align-items: center;
+    gap: var(--chart-spacing);
+    padding: var(--chart-spacing);
+    border: 1px solid var(--secondary-text-color);
+    border-radius: 10px;
+    cursor: pointer;
+  }
+  .chart__legend__color {
+    width: 10px;
+    min-width: 10px; /* To avoid parent flexbox compression */
+    height: 10px;
+    border-radius: 100%;
+  }
+  .chart__legend__text {
+    flex-grow: 1;
+    white-space: pre;
+    font-size: 11px;
+    font-weight: 500;
+  }
+  .chart__legend__text--bold {
+    font-weight: 700;
+    text-align: right;
+  }
+  @media only screen and (min-width: 600px) and (max-width: 1024px) {
+    .chart__legend__text--bold {
+      display: none;
+    }
+  }
+  .chart__legend__text--percent {
+    flex-grow: 0;
+    min-width: 50px;
+  }
+  @media only screen and (max-width: 600px) {
+    .row--pie {
+      flex-direction: column;
       margin-left: 0.5rem;
       margin-right: 0.5rem;
+    }
+
+    .chart {
+      align-items: center;
+    }
+
+    .chart--pie {
+      flex-direction: column;
     }
   }
 </style>
@@ -53,42 +123,60 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
 
 <div class="row">
   <div class="col">
-    <div class="chart-title">
+    <div class="chart__title">
       {{ data.history.last.active_installations | formatNumber }} Active Home
       Assistant Installations
     </div>
-    <canvas id="installationsChart"></canvas>
+    <div class="chart">
+      <canvas class="chart__canvas" id="installationsChart"></canvas>
+      <div class="chart__legend"></div>
+    </div>
   </div>
 </div>
 
 <div class="row">
   <div class="col">
-    <div class="chart-title">Version history</div>
-    <canvas id="versionHistoryChart"></canvas>
+    <div class="chart__title">Version history</div>
+    <div class="chart">
+      <canvas class="chart__canvas" id="versionHistoryChart"></canvas>
+      <div class="chart__legend"></div>
+    </div>
   </div>
 </div>
 
-<div class="row row-donut">
+<div class="row row--pie">
   <div class="col">
-    <div class="chart-title">Last releases</div>
-    <canvas id="lastReleaseChart"></canvas>
+    <div class="chart__title">Last releases</div>
+    <div class="chart chart--pie">
+      <canvas class="chart__canvas" id="lastReleaseChart"></canvas>
+      <div class="chart__legend"></div>
+    </div>
   </div>
 
   <div class="col">
-    <div class="chart-title">Installation types</div>
-    <canvas id="installationTypesChart"></canvas>
+    <div class="chart__title">Installation types</div>
+    <div class="chart chart--pie">
+      <canvas class="chart__canvas" id="installationTypesChart"></canvas>
+      <div class="chart__legend"></div>
+    </div>
   </div>
 </div>
 
-<div class="row row-donut">
+<div class="row row--pie">
   <div class="col">
-    <div class="chart-title">Top 5 used operating system versions</div>
-    <canvas id="top5OSversionChart"></canvas>
+    <div class="chart__title">Top 5 used operating system versions</div>
+    <div class="chart chart--pie">
+      <canvas class="chart__canvas" id="top5OSversionChart"></canvas>
+      <div class="chart__legend"></div>
+    </div>
   </div>
 
   <div class="col">
-    <div class="chart-title">Board types</div>
-    <canvas id="boardTypesChart"></canvas>
+    <div class="chart__title">Board types</div>
+    <div class="chart chart--pie">
+      <canvas class="chart__canvas" id="boardTypesChart"></canvas>
+      <div class="chart__legend"></div>
+    </div>
   </div>
 </div>
 
@@ -98,8 +186,7 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
 
 <script>
   function tooltipFooterCallback(item) {
-    let sum = 0;
-    item[0].dataset.data.forEach(data => { sum += Number(data) });
+    const sum = item[0].dataset.data.reduce((accumulator, value) => accumulator + value, 0);
     return `${(item[0].parsed * 100 / sum).toFixed(2)}%`;
   }
   const darkMode = window.matchMedia("(prefers-color-scheme:dark)").matches;
@@ -116,7 +203,7 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
       parsing: false,
       plugins: {
         legend: {
-          position: "bottom",
+          display: false,
         },
       },
       scales: {
@@ -127,18 +214,17 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
     },
     data: {
       datasets: {{ data.history | mergeInstallationHistory }},
-    }
+    },
+    plugins: [chartJsHtmlLegendPlugin],
   });
 
   new Chart("versionHistoryChart", {
     type: "line",
     options: {
       parsing: false,
-      aspectRatio: window.innerWidth < 400 ? 0.75 : window.innerWidth < 600 ? 0.8 : 1.5,
       plugins: {
         legend: {
-          align: "start",
-          position: "bottom",
+          display: false,
         },
       },
       scales: {
@@ -149,7 +235,8 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
     },
     data: {
       datasets: {{ data.history | mergeVersionHistory }},
-    }
+    },
+    plugins: [chartJsHtmlLegendPlugin],
   });
 
   new Chart("lastReleaseChart", {
@@ -157,7 +244,7 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
     options: {
       plugins: {
         legend: {
-          position: window.innerWidth < 600 ? "bottom" : "right",
+          display: false,
         },
         tooltip: {
           enabled: true,
@@ -173,7 +260,8 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
         data: {{ data.current.versions | versionSummary | values | json }},
         backgroundColor: {{ data.current.versions | versionSummary | keys | randomColors }}
       }]
-    }
+    },
+    plugins: [chartJsHtmlLegendPlugin],
   });
 
   new Chart("installationTypesChart", {
@@ -181,7 +269,7 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
     options: {
       plugins: {
         legend: {
-          position: window.innerWidth < 600 ? "bottom" : "right",
+          display: false,
         },
         tooltip: {
           enabled: true,
@@ -212,7 +300,8 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
           "{{ "Core" | randomColor }}"
         ]
       }]
-    }
+    },
+    plugins: [chartJsHtmlLegendPlugin],
   });
 
   new Chart("top5OSversionChart", {
@@ -220,7 +309,7 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
     options: {
       plugins: {
         legend: {
-          position: window.innerWidth < 600 ? "bottom" : "right",
+          display: false,
         },
         tooltip: {
           enabled: true,
@@ -236,7 +325,8 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
         data: {{ data.current.operating_system.versions | osVersionSummary | values | json }},
         backgroundColor: {{ data.current.operating_system.versions | osVersionSummary | keys | randomColors }}
       }]
-    }
+    },
+    plugins: [chartJsHtmlLegendPlugin],
   });
 
   new Chart("boardTypesChart", {
@@ -245,8 +335,7 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
     options: {
       plugins: {
         legend: {
-          align: "start",
-          position: window.innerWidth < 600 ? "bottom" : "right",
+          display: false,
         },
         tooltip: {
           enabled: true,
@@ -262,7 +351,8 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
         data: {{ sorted.data | json }},
         backgroundColor: {{ sorted.backgroundColor | json }},
       }]
-    }
+    },
+    plugins: [chartJsHtmlLegendPlugin],
   });
 
   new svgMap({

--- a/site/src/index.html
+++ b/site/src/index.html
@@ -90,6 +90,12 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
     flex-grow: 0;
     min-width: 50px;
   }
+  @media only screen and (max-width: 800px) {
+    .intro {
+      flex-direction: column;
+      row-gap: 1em;
+    }
+  }
   @media only screen and (max-width: 600px) {
     .row--pie {
       flex-direction: column;
@@ -107,7 +113,7 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
   }
 </style>
 
-<div class="row">
+<div class="row intro">
   <div class="col">
     Home Assistant allows users to share their usage data. It is used to
     influence Home Assistant development priorities and to convince

--- a/site/src/index.html
+++ b/site/src/index.html
@@ -10,99 +10,115 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
 ---
 
 <style>
-  .intro {
+  .row {
     display: flex;
-    flex-direction: row;
-    column-gap: 3em;
-    row-gap: 1em;
-    margin-bottom: 1em;
+    gap: 2rem;
+    margin-bottom: 2rem;
   }
-  .intro > * {
-    flex: 1;
+  .col {
+    flex: 1 0 0;
   }
   .chart-title {
     color: var(--secondary-text-color);
+    margin-bottom: 0.5rem;
   }
   canvas {
-    margin-bottom: 32px;
-  }
-  .half {
-    display: flex;
-  }
-  .half > * {
-    flex: 1;
-    margin: 0 16px;
-  }
-  @media only screen and (max-width: 800px) {
-    .intro {
-      flex-direction: column;
-    }
+    width: 100%;
   }
   @media only screen and (max-width: 600px) {
-    .half {
-      flex-direction: column-reverse;
+    .row {
+      flex-direction: column;
+    }
+
+    .row-donut {
+      margin-left: 0.5rem;
+      margin-right: 0.5rem;
     }
   }
 </style>
 
-<div class="intro">
-  <div>
+<div class="row">
+  <div class="col">
     Home Assistant allows users to share their usage data. It is used to
     influence Home Assistant development priorities and to convince
     manufacturers to add local control and privacy-focused features.
   </div>
-  <div>
+
+  <div class="col">
     Analytics in Home Assistant are opt-in and do not reflect the entire Home
     Assistant userbase. We estimate that less than a fourth of all Home Assistant
     users opt in.
   </div>
 </div>
 
-<div class="chart-title">
-  {{ data.history.last.active_installations | formatNumber }} Active Home
-  Assistant Installations
+<div class="row">
+  <div class="col">
+    <div class="chart-title">
+      {{ data.history.last.active_installations | formatNumber }} Active Home
+      Assistant Installations
+    </div>
+    <canvas id="installationsChart"></canvas>
+  </div>
 </div>
-<canvas id="installationsChart" style="width: 100%"></canvas>
 
-<div class="chart-title">Version history</div>
-<canvas id="versionHistoryChart" style="width: 100%"></canvas>
+<div class="row">
+  <div class="col">
+    <div class="chart-title">Version history</div>
+    <canvas id="versionHistoryChart"></canvas>
+  </div>
+</div>
 
-<div class="half">
-  <div>
+<div class="row row-donut">
+  <div class="col">
     <div class="chart-title">Last releases</div>
-    <canvas id="lastReleaseChart" style="width: 100%"></canvas>
+    <canvas id="lastReleaseChart"></canvas>
   </div>
-  <div>
+
+  <div class="col">
     <div class="chart-title">Installation types</div>
-    <canvas id="installationTypesChart" style="width: 100%"></canvas>
+    <canvas id="installationTypesChart"></canvas>
   </div>
 </div>
 
-<div class="half">
-  <div>
+<div class="row row-donut">
+  <div class="col">
     <div class="chart-title">Top 5 used operating system versions</div>
-    <canvas id="top5OSversionChart" style="width: 100%"></canvas>
+    <canvas id="top5OSversionChart"></canvas>
   </div>
-  <div>
+
+  <div class="col">
     <div class="chart-title">Board types</div>
-    <canvas id="boardTypesChart" style="width: 100%"></canvas>
+    <canvas id="boardTypesChart"></canvas>
   </div>
 </div>
 
-<div id="svgMap"></div>
+<div class="row">
+  <div id="installationsPerCountry" class="col"></div>
+</div>
 
 <script>
+  function tooltipFooterCallback(item) {
+    let sum = 0;
+    item[0].dataset.data.forEach(data => { sum += Number(data) });
+    return `${(item[0].parsed * 100 / sum).toFixed(2)}%`;
+  }
   const darkMode = window.matchMedia("(prefers-color-scheme:dark)").matches;
 
   Chart.defaults.color = darkMode ? "#9b9b9b" : "#727272";
   Chart.defaults.borderColor = darkMode ? "#202020" : "#ffffff";
+  Chart.defaults.responsive = true;
   Chart.defaults.plugins.legend.position = "right";
+  Chart.defaults.plugins.legend.labels.usePointStyle = true;
 
   new Chart("installationsChart", {
     type: "line",
     options: {
       parsing: false,
-      responsive: false,
+      plugins: {
+        legend: {
+          position: "bottom",
+        },
+      },
       scales: {
         x: {
           type: 'time',
@@ -118,7 +134,16 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
     type: "line",
     options: {
       parsing: false,
-      responsive: false,
+      aspectRatio: window.innerWidth < 600 ? 0.8 : 1.5,
+      plugins: {
+        legend: {
+          align: "start",
+          position: "bottom",
+          labels: {
+            usePointStyle: true
+          }
+        },
+      },
       scales: {
         x: {
           type: 'time',
@@ -134,14 +159,13 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
     type: "pie",
     options: {
       plugins: {
+        legend: {
+          position: window.innerWidth < 600 ? "bottom" : "right",
+        },
         tooltip: {
           enabled: true,
           callbacks: {
-            footer: (item) => {
-              let sum = 0;
-              item[0].dataset.data.forEach(data => { sum += Number(data) });
-              return `${(item[0].parsed * 100 / sum).toFixed(2)}%`;
-            }
+            footer: tooltipFooterCallback
           }
         },
       },
@@ -159,14 +183,13 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
     type: "pie",
     options: {
       plugins: {
+        legend: {
+          position: window.innerWidth < 600 ? "bottom" : "right",
+        },
         tooltip: {
           enabled: true,
           callbacks: {
-            footer: (item) => {
-              let sum = 0;
-              item[0].dataset.data.forEach(data => { sum += Number(data) });
-              return `${(item[0].parsed * 100 / sum).toFixed(2)}%`;
-            }
+            footer: tooltipFooterCallback
           }
         },
       },
@@ -199,14 +222,13 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
     type: "pie",
     options: {
       plugins: {
+        legend: {
+          position: window.innerWidth < 600 ? "bottom" : "right",
+        },
         tooltip: {
           enabled: true,
           callbacks: {
-            footer: (item) => {
-              let sum = 0;
-              item[0].dataset.data.forEach(data => { sum += Number(data) });
-              return `${(item[0].parsed * 100 / sum).toFixed(2)}%`;
-            }
+            footer: tooltipFooterCallback
           }
         },
       },
@@ -225,14 +247,14 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
     type: "pie",
     options: {
       plugins: {
+        legend: {
+          align: "start",
+          position: window.innerWidth < 600 ? "bottom" : "right",
+        },
         tooltip: {
           enabled: true,
           callbacks: {
-            footer: (item) => {
-              let sum = 0;
-              item[0].dataset.data.forEach(data => { sum += Number(data) });
-              return `${(item[0].parsed * 100 / sum).toFixed(2)}%`;
-            }
+            footer: tooltipFooterCallback
           }
         },
       },
@@ -247,19 +269,19 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
   });
 
   new svgMap({
-    targetElementID: 'svgMap',
+    targetElementID: 'installationsPerCountry',
     colorMin: "#80CBC4",
     colorMax: "#004D40",
     hideFlag: true,
     initialZoom: 1.0,
     data: {
-            data: {
-              installations: {
-                format: "{0} Installations",
-              },
-            },
-            applyData: "installations",
-            values: {{ data.current.countries | countriesForMap }},
-          },
+      data: {
+        installations: {
+          format: "{0} Installations",
+        },
+      },
+      applyData: "installations",
+      values: {{ data.current.countries | countriesForMap }},
+    },
   });
 </script>

--- a/site/src/index.html
+++ b/site/src/index.html
@@ -139,9 +139,6 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
         legend: {
           align: "start",
           position: "bottom",
-          labels: {
-            usePointStyle: true
-          }
         },
       },
       scales: {

--- a/site/src/index.html
+++ b/site/src/index.html
@@ -134,7 +134,7 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
     type: "line",
     options: {
       parsing: false,
-      aspectRatio: window.innerWidth < 600 ? 0.8 : 1.5,
+      aspectRatio: window.innerWidth < 400 ? 0.75 : window.innerWidth < 600 ? 0.8 : 1.5,
       plugins: {
         legend: {
           align: "start",

--- a/site/src/index.html
+++ b/site/src/index.html
@@ -36,11 +36,11 @@ extra_head_contents: <script src="/static/svg-pan-zoom.min.js"></script>
     margin-bottom: 0.5rem;
   }
   .chart__canvas {
-    width: 100% !important; /* !important to be stringer that inline styling added by Chart.js */
+    width: 100% !important; /* !important to be stronger that inline styling added by Chart.js */
   }
   .chart--pie .chart__canvas {
-    width: 50% !important; /* !important to be stringer that inline styling added by Chart.js */
-    height: auto !important; /* !important to be stringer that inline styling added by Chart.js */
+    width: 50% !important; /* !important to be stronger that inline styling added by Chart.js */
+    height: auto !important; /* !important to be stronger that inline styling added by Chart.js */
   }
   .chart__legend {
     color: var(--secondary-text-color);


### PR DESCRIPTION
fixes #926 & fixes #973 

How:
- Explicitly activate chart responsive mode
- use a custom HTML Legend Plugin that make the chart legend responsive ([official exemple](https://www.chartjs.org/docs/latest/samples/legend/html.html))
- use `plugins.legend.labels.usePointStyle = true` to reduce the legend item width (and better align with the chart style)

Also:
- Code style cleanup with better reusability
  - `row/col` design inspired from the Bootstrap framework : https://getbootstrap.com/docs/5.3/layout/columns/
- Avoid inline styling
- Factorise `plugins.tooltip.callbacks.footer` into `tooltipFooterCallback()`
- Change the div ID for the installations per countries from `svgMap` (?) to `installationsPerCountry`

ChartJS Doc:
- https://www.chartjs.org/docs/latest/configuration/legend.html
- https://www.chartjs.org/docs/latest/configuration/responsive.html

| BEFORE | AFTER |
|  -------- | ------- |
| desktop (width: 1440px) <img width="1440" src="https://github.com/user-attachments/assets/caad5800-97a0-49a0-87be-a44a78074134" /> | desktop (width: 1440px) <img width="1440" src="https://github.com/user-attachments/assets/84fc2bde-79ea-49c5-9232-a9ed44638370" /> |
| mobile iPad mini (width: 768px) ⚠️ screen capture tool is missing some part of the screen <img width="768"  src="https://github.com/user-attachments/assets/46a6436a-07e5-43fc-a380-64fd8c56c803" /> | mobile iPad mini (width: 768px) ⚠️ screen capture tool is missing some part of the screen <img width="768" src="https://github.com/user-attachments/assets/e50585f7-a9e3-48da-9408-7eda3766dc0a" /> |
| mobile iPhone 12 Pro (width: 390px) <img width="390" src="https://github.com/user-attachments/assets/cad37324-a14a-47cd-8f45-5860196852fc" /> | mobile iPhone 12 Pro (width: 390px) <img width="390"  src="https://github.com/user-attachments/assets/2245560d-6c35-43c2-be5b-b7385c124251" /> |