### PR TITLE
Rename addons to apps

### DIFF
--- a/site/.eleventy.js
+++ b/site/.eleventy.js
@@ -7,6 +7,7 @@ const versionTools = require("./src/tools/versions");
 
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy({ "src/_static": "static" });
+  eleventyConfig.addPassthroughCopy("src/_redirects");
   eleventyConfig.addPassthroughCopy({
     "../node_modules/svgmap/dist/svgMap.min.css": "static/svgMap.min.css",
     "../node_modules/svgmap/dist/svgMap.min.js": "static/svgMap.min.js",

--- a/site/src/_layouts/base.html
+++ b/site/src/_layouts/base.html
@@ -9,8 +9,8 @@ navigation:
     path: /statistics
   - name: Integrations
     path: /integrations
-  - name: Add-ons
-    path: /add-ons
+  - name: Apps
+    path: /apps
 ---
 
 <!DOCTYPE html>

--- a/site/src/_redirects
+++ b/site/src/_redirects
@@ -1,0 +1,1 @@
+/add-ons /apps 301

--- a/site/src/apps.html
+++ b/site/src/apps.html
@@ -1,6 +1,6 @@
 ---
 layout: table
-title: Add-ons
+title: Apps
 addons_details:
   core_ada:
     name: Ada
@@ -245,5 +245,5 @@ addons_details:
 <div class="note">
   {{ data.current.reports_addons | formatNumber }} of {{ data.current.extended_data_from | formatNumber }}
   ({{ data.current.extended_data_from | calculatePercentage: data.current.reports_addons }}%)
-  installations have chosen to share their used add-ons
+  installations have chosen to share their used apps
 </div>

--- a/site/src/statistics.html
+++ b/site/src/statistics.html
@@ -49,7 +49,7 @@ title: Statistics
 {% for median in medians %}
 {% assign dataset = "avg_" | append: median %}
 {% assign display_name = median %}
-{% # Temporary: Display "apps" while still using "addons" data until full rename is complete %}
+{% comment %}Temporary: Display "apps" while still using "addons" data until full rename is complete{% endcomment %}
 {% if median == "addons" %}{% assign display_name = "apps" %}{% endif %}
   <div class="metric">
     <span>{{ display_name }}</span>

--- a/site/src/statistics.html
+++ b/site/src/statistics.html
@@ -48,8 +48,11 @@ title: Statistics
 <div class="grid">
 {% for median in medians %}
 {% assign dataset = "avg_" | append: median %}
+{% assign display_name = median %}
+{% # Temporary: Display "apps" while still using "addons" data until full rename is complete %}
+{% if median == "addons" %}{% assign display_name = "apps" %}{% endif %}
   <div class="metric">
-    <span>{{ median }}</span>
+    <span>{{ display_name }}</span>
     <span>{{ data.current[dataset] }}</span>
   </div>
 {% endfor %}


### PR DESCRIPTION
Just renamed the user facing strings.
addons.json is not touched and a apps.json currently does not exist. We should do this change in a follow up as also the worker needs to be updated