### PR TITLE
Add 30-day comparison columns to integrations table

### DIFF
--- a/site/src/_layouts/table.html
+++ b/site/src/_layouts/table.html
@@ -118,7 +118,7 @@ layout: base
   const paginator = document.getElementById("paginator");
   let tableStart = 1;
   let tableLimit = tableLimitSelector.value;
-  const tableHeader = `
+  const tableHeader = typeof customTableHeader !== 'undefined' ? customTableHeader : `
     <tr class="table-header">
       <th class="idx"></th>
       <th>Name</th>

--- a/site/src/integrations.html
+++ b/site/src/integrations.html
@@ -37,13 +37,15 @@ title: Integrations
 
   let monthAgoLookup = null;
   if (monthAgoData && monthAgoData.integrations) {
-    const monthAgoEntries = tableEntries
-      .map(e => ({ domain: e.domain, installations: monthAgoData.integrations[e.domain] || 0 }))
+    const snapshotEntries = Object.entries(monthAgoData.integrations)
+      .map(([domain, installations]) => ({ domain, installations }))
       .sort((a, b) => b.installations - a.installations);
-    monthAgoLookup = {};
-    monthAgoEntries.forEach((e, idx) => {
-      monthAgoLookup[e.domain] = { position: idx + 1, installations: e.installations };
-    });
+    if (snapshotEntries.length > 0) {
+      monthAgoLookup = {};
+      snapshotEntries.forEach((e, idx) => {
+        monthAgoLookup[e.domain] = { position: idx + 1, installations: e.installations };
+      });
+    }
   }
 
   if (monthAgoLookup) {
@@ -52,8 +54,8 @@ title: Integrations
       <th class="idx"></th>
       <th>Name</th>
       <th class="installations">Installations</th>
-      <th class="change">± Installations<br><small>vs. 30 days ago</small></th>
-      <th class="change">± Position<br><small>vs. 30 days ago</small></th>
+      <th class="change">± Installations</th>
+      <th class="change">± Position</th>
     </tr>
     `;
   }

--- a/site/src/integrations.html
+++ b/site/src/integrations.html
@@ -3,24 +3,99 @@ layout: table
 title: Integrations
 ---
 
+<style>
+  .change {
+    text-align: right;
+    white-space: nowrap;
+    font-size: 0.85em;
+  }
+  .change.positive {
+    color: #4caf50;
+  }
+  .change.negative {
+    color: #f44336;
+  }
+  .change.neutral {
+    color: var(--secondary-text-color);
+  }
+  @media only screen and (max-width: 600px) {
+    .change {
+      font-size: 0.75em;
+    }
+  }
+</style>
+
 <script>
   const tableEntries = {{ data.current.integrations | sortIntegrations: integration_details | json }};
   const reportsIntegrations = Number({{ data.current.reports_integrations }});
-  const createTableRow = (entry) =>  `
-  <tr>
-    <td class="idx">${entry.idx}</td>
-    <td>
-      <a title="Documentation" href="https://www.home-assistant.io/integrations/${entry.domain}" target="_blank">
-        <img src="https://brands.home-assistant.io/_/${entry.domain}/${darkMode ? 'dark_' : ''}icon.png">
-        <span>${entry.name}</span>
-      </a>
-    </td>
-    <td class="installations">
-      <span>${Intl.NumberFormat().format(entry.installations)}</span>
-      <span>(${((100 * entry.installations) / reportsIntegrations).toFixed(1)}%)</span>
-    </td>
-  </tr>
-  `
+
+  {% if data.month_ago %}
+  const monthAgoData = {{ data.month_ago | json }};
+  {% else %}
+  const monthAgoData = null;
+  {% endif %}
+
+  let monthAgoLookup = null;
+  if (monthAgoData && monthAgoData.integrations) {
+    const monthAgoEntries = tableEntries
+      .map(e => ({ domain: e.domain, installations: monthAgoData.integrations[e.domain] || 0 }))
+      .sort((a, b) => b.installations - a.installations);
+    monthAgoLookup = {};
+    monthAgoEntries.forEach((e, idx) => {
+      monthAgoLookup[e.domain] = { position: idx + 1, installations: e.installations };
+    });
+  }
+
+  if (monthAgoLookup) {
+    var customTableHeader = `
+    <tr class="table-header">
+      <th class="idx"></th>
+      <th>Name</th>
+      <th class="installations">Installations</th>
+      <th class="change">± Installations<br><small>vs. 30 days ago</small></th>
+      <th class="change">± Position<br><small>vs. 30 days ago</small></th>
+    </tr>
+    `;
+  }
+
+  const createTableRow = (entry) => {
+    let changeHtml = '';
+    if (monthAgoLookup) {
+      const old = monthAgoLookup[entry.domain];
+      const isNew = !old || old.installations === 0;
+      const oldCount = old ? old.installations : 0;
+      const diff = entry.installations - oldCount;
+      const diffStr = isNew ? 'NEW' : diff === 0 ? '—' : diff > 0 ? `+${Intl.NumberFormat().format(diff)}` : Intl.NumberFormat().format(diff);
+      const diffClass = isNew ? 'positive' : diff > 0 ? 'positive' : diff < 0 ? 'negative' : 'neutral';
+
+      const oldPos = old ? old.position : null;
+      const posDiff = oldPos !== null ? oldPos - entry.idx : null;
+      const posStr = isNew ? 'NEW' : posDiff > 0 ? `▲ ${posDiff}` : posDiff < 0 ? `▼ ${Math.abs(posDiff)}` : '—';
+      const posClass = isNew ? 'positive' : posDiff > 0 ? 'positive' : posDiff < 0 ? 'negative' : 'neutral';
+
+      changeHtml = `
+        <td class="change ${diffClass}"><span>${diffStr}</span></td>
+        <td class="change ${posClass}"><span>${posStr}</span></td>
+      `;
+    }
+
+    return `
+    <tr>
+      <td class="idx">${entry.idx}</td>
+      <td>
+        <a title="Documentation" href="https://www.home-assistant.io/integrations/${entry.domain}" target="_blank">
+          <img src="https://brands.home-assistant.io/_/${entry.domain}/${darkMode ? 'dark_' : ''}icon.png">
+          <span>${entry.name}</span>
+        </a>
+      </td>
+      <td class="installations">
+        <span>${Intl.NumberFormat().format(entry.installations)}</span>
+        <span>(${((100 * entry.installations) / reportsIntegrations).toFixed(1)}%)</span>
+      </td>
+      ${changeHtml}
+    </tr>
+    `;
+  }
 </script>
 
 <div class="note">
@@ -28,3 +103,11 @@ title: Integrations
   ({{ data.current.extended_data_from | calculatePercentage: data.current.reports_integrations }}%)
   installations have chosen to share their used integrations
 </div>
+{% if data.month_ago %}
+<div class="note">
+  ± Installations and ± Position compared to
+  <script>
+    document.write(new Date({{ data.month_ago.timestamp }}).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' }));
+  </script>
+</div>
+{% endif %}

--- a/worker/src/data.ts
+++ b/worker/src/data.ts
@@ -198,10 +198,17 @@ export interface AnalyticsDataCurrent {
   };
 }
 
+export interface MonthAgoData {
+  timestamp: number;
+  integrations: Record<string, number>;
+  reports_integrations: number;
+}
+
 export interface AnalyticsData {
   schema_version: number;
   history: AnalyticsDataHistory[];
   current: AnalyticsDataCurrent;
+  month_ago?: MonthAgoData;
 }
 
 export interface IncomingPayload {

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -301,11 +301,13 @@ async function processQueue(
     const storedAnalytics = await getAnalyticsData(event);
 
     // Update month_ago by looking up the history entry closest to 30 days ago.
-    // This gives a fresh "vs. 30 days ago" comparison on every daily run.
-    // Costs 1 KV list + 1 KV read per day.
+    // This gives a fresh "vs. ~30 days ago" comparison on every daily run.
+    // Costs 1 KV read plus 1 or more KV list calls per day, because listKV may
+    // paginate once the number of history keys exceeds the per-call limit.
     const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
     const targetTimestamp = timestamp - THIRTY_DAYS_MS;
     const historyKeys = await listKV(event, KV_PREFIX_HISTORY);
+    let newMonthAgo = undefined;
     if (historyKeys.length > 0) {
       const prefixLen = KV_PREFIX_HISTORY.length + 1; // "history:".length
       const closestKey = historyKeys.reduce((best, entry) => {
@@ -315,18 +317,24 @@ async function processQueue(
           ? entry
           : best;
       });
+      const closestTs = Number(closestKey.name.slice(prefixLen));
       const monthAgoEntry = await event.env.KV.get<{
         integrations: Record<string, number>;
         reports_integrations: number;
       }>(closestKey.name, "json");
-      if (monthAgoEntry) {
-        storedAnalytics.month_ago = {
-          timestamp: Number(closestKey.name.slice(prefixLen)),
+      if (
+        monthAgoEntry &&
+        monthAgoEntry.integrations &&
+        Object.keys(monthAgoEntry.integrations).length > 0
+      ) {
+        newMonthAgo = {
+          timestamp: closestTs,
           integrations: monthAgoEntry.integrations,
           reports_integrations: monthAgoEntry.reports_integrations,
         };
       }
     }
+    storedAnalytics.month_ago = newMonthAgo;
 
     storedAnalytics.current = {
       ...queue_data,

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -300,6 +300,34 @@ async function processQueue(
     const queue_data = processQueueData(queue.data);
     const storedAnalytics = await getAnalyticsData(event);
 
+    // Update month_ago by looking up the history entry closest to 30 days ago.
+    // This gives a fresh "vs. 30 days ago" comparison on every daily run.
+    // Costs 1 KV list + 1 KV read per day.
+    const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+    const targetTimestamp = timestamp - THIRTY_DAYS_MS;
+    const historyKeys = await listKV(event, KV_PREFIX_HISTORY);
+    if (historyKeys.length > 0) {
+      const prefixLen = KV_PREFIX_HISTORY.length + 1; // "history:".length
+      const closestKey = historyKeys.reduce((best, entry) => {
+        const entryTs = Number(entry.name.slice(prefixLen));
+        const bestTs = Number(best.name.slice(prefixLen));
+        return Math.abs(entryTs - targetTimestamp) < Math.abs(bestTs - targetTimestamp)
+          ? entry
+          : best;
+      });
+      const monthAgoEntry = await event.env.KV.get<{
+        integrations: Record<string, number>;
+        reports_integrations: number;
+      }>(closestKey.name, "json");
+      if (monthAgoEntry) {
+        storedAnalytics.month_ago = {
+          timestamp: Number(closestKey.name.slice(prefixLen)),
+          integrations: monthAgoEntry.integrations,
+          reports_integrations: monthAgoEntry.reports_integrations,
+        };
+      }
+    }
+
     storedAnalytics.current = {
       ...queue_data,
       last_updated: timestamp,

--- a/worker/src/utils/migrate.ts
+++ b/worker/src/utils/migrate.ts
@@ -82,5 +82,10 @@ export const migrateAnalyticsData = (data: any): AnalyticsData => {
     }
   }
 
+  // Preserve month_ago snapshot across migrations
+  if (data.month_ago) {
+    analyticsData.month_ago = data.month_ago;
+  }
+
   return analyticsData;
 };

--- a/worker/tests/handlers/schedule.spec.ts
+++ b/worker/tests/handlers/schedule.spec.ts
@@ -5,6 +5,7 @@ import {
   KV_KEY_CORE_ANALYTICS,
   KV_KEY_CUSTOM_INTEGRATIONS,
   KV_KEY_QUEUE,
+  KV_PREFIX_HISTORY,
   ScheduledTask,
   SCHEMA_VERSION_ANALYTICS,
   SCHEMA_VERSION_QUEUE,
@@ -258,6 +259,7 @@ describe("schedule handler", function () {
       const event = MockedScheduledEvent({
         controller: { cron: ScheduledTask.PROCESS_QUEUE },
       });
+      const historyKey = `history:${new Date().getTime() - 30 * 24 * 60 * 60 * 1000}`;
       (event.env.KV.get as jest.Mock).mockImplementation(
         async (key: string) => {
           if (key === KV_KEY_QUEUE) {
@@ -268,6 +270,13 @@ describe("schedule handler", function () {
                 name: `uuid:${i}`,
               })),
               data: createQueueData(),
+            };
+          }
+
+          if (key === historyKey) {
+            return {
+              integrations: { light: 1000, switch: 500 },
+              reports_integrations: 400000,
             };
           }
 
@@ -285,10 +294,22 @@ describe("schedule handler", function () {
         }
       );
 
+      (event.env.KV.list as jest.Mock).mockImplementation(
+        async (data: { prefix: string; cursor?: string }) => ({
+          keys:
+            data.prefix === KV_PREFIX_HISTORY
+              ? [{ name: historyKey }]
+              : [],
+          list_complete: true,
+        })
+      );
+
       await handleSchedule(event, MockSentry);
 
       expect(event.env.KV.get).toBeCalledWith(KV_KEY_QUEUE, "json");
-      expect(event.env.KV.list).not.toBeCalled();
+      expect(event.env.KV.list).toBeCalledWith(
+        expect.objectContaining({ prefix: KV_PREFIX_HISTORY })
+      );
       expect(MockSentry.setTag).toBeCalledWith(
         "scheduled-task",
         "PROCESS_QUEUE"
@@ -305,6 +326,14 @@ describe("schedule handler", function () {
       expect(event.env.KV.put).toBeCalledWith(
         KV_KEY_CORE_ANALYTICS,
         expect.not.stringContaining("invalid_board")
+      );
+      expect(event.env.KV.put).toBeCalledWith(
+        KV_KEY_CORE_ANALYTICS,
+        expect.stringContaining('"month_ago"')
+      );
+      expect(event.env.KV.put).toBeCalledWith(
+        KV_KEY_CORE_ANALYTICS,
+        expect.stringContaining('"reports_integrations":400000')
       );
       expect(event.env.KV.put).toBeCalledWith(
         KV_KEY_ADDONS,

--- a/worker/tests/handlers/schedule.spec.ts
+++ b/worker/tests/handlers/schedule.spec.ts
@@ -259,7 +259,7 @@ describe("schedule handler", function () {
       const event = MockedScheduledEvent({
         controller: { cron: ScheduledTask.PROCESS_QUEUE },
       });
-      const historyKey = `history:${new Date().getTime() - 30 * 24 * 60 * 60 * 1000}`;
+      const historyKey = `${KV_PREFIX_HISTORY}:${new Date().getTime() - 30 * 24 * 60 * 60 * 1000}`;
       (event.env.KV.get as jest.Mock).mockImplementation(
         async (key: string) => {
           if (key === KV_KEY_QUEUE) {

--- a/worker/tests/utils/migrate.spec.ts
+++ b/worker/tests/utils/migrate.spec.ts
@@ -58,4 +58,19 @@ describe("migrateAnalyticsData", function () {
         .active_installations
     ).toBe(1337);
   });
+
+  it("preserves month_ago across migrations", function () {
+    const monthAgo = {
+      timestamp: 1700000000000,
+      integrations: { light: 5000, switch: 3000 },
+      reports_integrations: 400000,
+    };
+    const migrated = migrateAnalyticsData({ month_ago: monthAgo });
+    expect(migrated.month_ago).toEqual(monthAgo);
+  });
+
+  it("leaves month_ago undefined when not present", function () {
+    const migrated = migrateAnalyticsData({});
+    expect(migrated.month_ago).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Add 30-day comparison columns to integrations table

### What

Two new columns on the integrations page: **± Installations** and **± Position**, showing how each integration changed compared to ~30 days ago.

### Why

Makes it easy to measure the impact of changes across releases — e.g. after adding new discovery for UniFi Protect, UniFi Access and UniFi Network, you can immediately see how their install numbers and ranking evolve over the following month.

### How it works

- Once per day (when the processing queue completes), the worker looks up the KV history entry closest to 30 days ago and stores it as `month_ago` inside the existing `AnalyticsData` object
- No new KV keys, no extra scheduled tasks — ~2 additional KV operations per day (list + read), negligible cost
- The site embeds `month_ago.integrations` into the page at build time; all comparison logic runs client-side
- If no `month_ago` data exists yet (first deployment) the columns are simply hidden until history is available
- New integrations not present in the snapshot are labelled **NEW**
- Unchanged values show **—**