### PR TITLE
fix: add trailing newline to prometheus metrics output

### DIFF
--- a/site/src/prometheus/addons.liquid
+++ b/site/src/prometheus/addons.liquid
@@ -20,4 +20,4 @@ addon_protected{slug="{{addon[0]}}"} {{addon[1]["protected"]}}
 {%- for version in addon[1]["versions"] %}
 addon_version{slug="{{addon[0]}}",version="{{version[0]}}"} {{version[1]}}
 {%- endfor %}
-{%- endfor -%}
+{%- endfor %}

--- a/site/src/prometheus/custom_integrations.liquid
+++ b/site/src/prometheus/custom_integrations.liquid
@@ -17,5 +17,5 @@ eleventyAllowMissingExtension: true
 custom_integration{domain="{{ integration[0] }}"} {{ integration[1]["total"] }}
 {%- for version in integration[1]["versions"] %}
 custom_integration_version{domain="{{ integration[0] }}",version="{{version[0]}}"} {{ version[1] }}
-{%- endfor %}
+{%- endfor -%}
 {%- endfor %}

--- a/site/src/prometheus/custom_integrations.liquid
+++ b/site/src/prometheus/custom_integrations.liquid
@@ -17,5 +17,5 @@ eleventyAllowMissingExtension: true
 custom_integration{domain="{{ integration[0] }}"} {{ integration[1]["total"] }}
 {%- for version in integration[1]["versions"] %}
 custom_integration_version{domain="{{ integration[0] }}",version="{{version[0]}}"} {{ version[1] }}
-{%- endfor -%}
-{%- endfor -%}
+{%- endfor %}
+{%- endfor %}

--- a/site/src/prometheus/integrations.liquid
+++ b/site/src/prometheus/integrations.liquid
@@ -15,4 +15,4 @@ eleventyAllowMissingExtension: true
 
 {%- for integration in data.current.integrations %}
 integration{domain="{{ integration[0] }}"} {{ integration[1] }}
-{%- endfor -%}
+{%- endfor %}


### PR DESCRIPTION
## Summary
- Victoria Metrics requires the metrics exposition to end with a trailing empty line; without it, the scrape is treated as invalid.
- Replace the whitespace-trimming `{%- endfor -%}` tags at the end of the prometheus `.liquid` templates so the rendered output ends with a newline.
- Affects `addons.liquid`, `custom_integrations.liquid`, and `integrations.liquid`. The `base.liquid` was already correctly formatted.

Note: This is a temporary fix. We will migrate to a push-based solution in the short term.