### PR TITLE
feat: accept custom integration issue_tracker

### DIFF
--- a/site/src/prometheus/custom_integrations.liquid
+++ b/site/src/prometheus/custom_integrations.liquid
@@ -18,4 +18,7 @@ custom_integration{domain="{{ integration[0] }}"} {{ integration[1]["total"] }}
 {%- for version in integration[1]["versions"] %}
 custom_integration_version{domain="{{ integration[0] }}",version="{{version[0]}}"} {{ version[1] }}
 {%- endfor -%}
+{%- for issue_tracker in integration[1]["issue_trackers"] %}
+custom_integration_issue_tracker{domain="{{ integration[0] }}",issue_tracker="{{issue_tracker[0]}}"} {{ issue_tracker[1] }}
+{%- endfor -%}
 {%- endfor %}

--- a/worker/src/data.ts
+++ b/worker/src/data.ts
@@ -6,7 +6,7 @@ export const KV_PREFIX_HISTORY = "history";
 export const KV_PREFIX_UUID = "uuid";
 export const KV_MAX_PROCESS_ENTRIES = 800;
 
-export const SCHEMA_VERSION_QUEUE = 15;
+export const SCHEMA_VERSION_QUEUE = 16;
 export const SCHEMA_VERSION_ANALYTICS = 4;
 
 export const BRANDS_DOMAINS_URL =
@@ -102,7 +102,11 @@ export interface QueueData {
   >;
   custom_integrations: Record<
     string,
-    { total: number; versions: Record<string, number> }
+    {
+      total: number;
+      versions: Record<string, number>;
+      issue_trackers: Record<string, number>;
+    }
   >;
   reports_integrations: number;
   reports_addons: number;
@@ -215,7 +219,11 @@ export interface IncomingPayload {
   automation_count?: number;
   country?: string;
   region?: string;
-  custom_integrations?: { domain: string; version?: string | null }[];
+  custom_integrations?: {
+    domain: string;
+    issue_tracker?: string | null;
+    version?: string | null;
+  }[];
   operating_system?: { board: string; version?: string | null };
   supervisor?: { supported: boolean; healthy: boolean; arch?: string };
   installation_type: string;

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -531,6 +531,7 @@ function combineEntryData(
         data.custom_integrations[custom_integration.domain] = {
           total: 0,
           versions: {},
+          issue_trackers: {},
         };
       }
       data.custom_integrations[custom_integration.domain].total++;
@@ -540,6 +541,15 @@ function combineEntryData(
         ] = bumpValue(
           data.custom_integrations[custom_integration.domain].versions[
             custom_integration.version
+          ]
+        );
+      }
+      if (custom_integration.issue_tracker) {
+        data.custom_integrations[custom_integration.domain].issue_trackers[
+          custom_integration.issue_tracker
+        ] = bumpValue(
+          data.custom_integrations[custom_integration.domain].issue_trackers[
+            custom_integration.issue_tracker
           ]
         );
       }

--- a/worker/src/utils/validate.ts
+++ b/worker/src/utils/validate.ts
@@ -60,7 +60,13 @@ export const IncomingPayloadStruct = object({
   country: optional(size(string(), 2, 2)),
   region: optional(size(string(), 2, 2)),
   custom_integrations: optional(
-    array(object({ domain: string(), version: optional(nullable(string())) }))
+    array(
+      object({
+        domain: string(),
+        issue_tracker: optional(nullable(string())),
+        version: optional(nullable(string())),
+      })
+    )
   ),
   installation_type: is_ha_installation_type,
   integration_count: optional(number()),

--- a/worker/tests/handlers/schedule.spec.ts
+++ b/worker/tests/handlers/schedule.spec.ts
@@ -275,7 +275,11 @@ describe("schedule handler", function () {
             integrations: ["core_valid"],
             custom_integrations: [
               { domain: "custom_invalid", version: "1.2.3" },
-              { domain: "custom_valid", version: "1.2.3" },
+              {
+                domain: "custom_valid",
+                version: "1.2.3",
+                issue_tracker: "https://github.com/custom_valid/issues",
+              },
             ],
             operating_system: {
               board: "invalid_board",
@@ -312,7 +316,7 @@ describe("schedule handler", function () {
       );
       expect(event.env.KV.put).toBeCalledWith(
         KV_KEY_CUSTOM_INTEGRATIONS,
-        '{"custom_valid":{"total":500,"versions":{"1.2.3":500}}}'
+        '{"custom_valid":{"total":500,"versions":{"1.2.3":500},"issue_trackers":{"https://github.com/custom_valid/issues":500}}}'
       );
       expect(event.env.KV.put).toBeCalledWith(
         expect.stringContaining("history:"),
@@ -320,6 +324,83 @@ describe("schedule handler", function () {
       );
       expect(MockFetch).toBeCalledTimes(3);
       expect(event.env.KV.put).toBeCalledTimes(5);
+    });
+
+    it("Aggregates issue_trackers across installs", async () => {
+      const event = MockedScheduledEvent({
+        controller: { cron: ScheduledTask.PROCESS_QUEUE },
+      });
+
+      const upstreamTracker = "https://github.com/custom_valid/issues";
+      const forkTracker = "https://github.com/fork/custom_valid/issues";
+
+      // Three installs report the same brands-valid domain with three different
+      // states: upstream tracker, fork tracker, no tracker. Plus one install
+      // reports an unrelated brands-valid domain with a tracker.
+      const payloadsByUuid: Record<string, any> = {
+        "uuid:0": {
+          custom_integrations: [
+            {
+              domain: "custom_valid",
+              version: "1.2.3",
+              issue_tracker: upstreamTracker,
+            },
+          ],
+        },
+        "uuid:1": {
+          custom_integrations: [
+            {
+              domain: "custom_valid",
+              version: "1.2.3",
+              issue_tracker: upstreamTracker,
+            },
+          ],
+        },
+        "uuid:2": {
+          custom_integrations: [
+            {
+              domain: "custom_valid",
+              version: "1.2.3",
+              issue_tracker: forkTracker,
+            },
+          ],
+        },
+        "uuid:3": {
+          custom_integrations: [
+            { domain: "custom_valid", version: "1.2.3" },
+          ],
+        },
+      };
+
+      (event.env.KV.get as jest.Mock).mockImplementation(
+        async (key: string) => {
+          if (key === KV_KEY_QUEUE) {
+            return {
+              schema_version: SCHEMA_VERSION_QUEUE,
+              process_complete: false,
+              entries: Object.keys(payloadsByUuid),
+              data: createQueueData(),
+            };
+          }
+          return payloadsByUuid[key];
+        }
+      );
+
+      await handleSchedule(event, MockSentry);
+
+      expect(event.env.KV.put).toBeCalledWith(
+        KV_KEY_CUSTOM_INTEGRATIONS,
+        JSON.stringify({
+          custom_valid: {
+            total: 4,
+            versions: { "1.2.3": 4 },
+            issue_trackers: {
+              [upstreamTracker]: 2,
+              [forkTracker]: 1,
+            },
+          },
+        })
+      );
     });
 
     it("Wait for reset", async () => {

--- a/worker/tests/utils/validate.spec.ts
+++ b/worker/tests/utils/validate.spec.ts
@@ -68,7 +68,13 @@ describe("createIncomingPayload", function () {
       addons: [ADDON],
       automation_count: 1,
       country: "XX",
-      custom_integrations: [{ domain: "awesome_custom", version: null }],
+      custom_integrations: [
+        {
+          domain: "awesome_custom",
+          version: null,
+          issue_tracker: "https://github.com/awesome/custom/issues",
+        },
+      ],
       integration_count: 1,
       integrations: ["awesome"],
       operating_system: { board: "blue", version: "123" },
@@ -110,6 +116,35 @@ describe("createIncomingPayload", function () {
       addons: [{ ...ADDON, auto_update: null }],
     });
     expect(payload.addons![0].auto_update).toBe(false);
+  });
+
+  it("custom_integrations item without issue_tracker", function () {
+    const payload = createIncomingPayload({
+      ...BASE_PAYLOAD,
+      custom_integrations: [{ domain: "awesome_custom", version: "1.2.3" }],
+    });
+    expect(payload.custom_integrations![0].issue_tracker).toBeUndefined();
+  });
+
+  it("custom_integrations item with null issue_tracker", function () {
+    const payload = createIncomingPayload({
+      ...BASE_PAYLOAD,
+      custom_integrations: [
+        { domain: "awesome_custom", version: "1.2.3", issue_tracker: null },
+      ],
+    });
+    expect(payload.custom_integrations![0].issue_tracker).toBeNull();
+  });
+
+  it("custom_integrations item with non-string issue_tracker is rejected", function () {
+    expect(() => {
+      createIncomingPayload({
+        ...BASE_PAYLOAD,
+        custom_integrations: [
+          { domain: "awesome_custom", version: "1.2.3", issue_tracker: 42 },
+        ],
+      });
+    }).toThrow(/issue_tracker/);
   });
 
   it("Valid versions", function () {


### PR DESCRIPTION
## Summary

Accepts the new `issue_tracker` field on each `custom_integrations` item in the analytics payload (introduced upstream in home-assistant/core#169537), and surfaces it both in [`custom_integrations.json`](https://analytics.home-assistant.io/custom_integrations.json) and on the [`/prometheus/custom_integrations`](https://analytics.home-assistant.io/prometheus/custom_integrations) endpoint.

The goal — per the upstream PR — is to make it possible to find the source repos of widely-used custom integrations that aren't published on HACS.

## ⚠️ Deployment ordering

**This PR must be deployed before home-assistant/core#169537 ships in a stable Core release.**

The current worker validates `custom_integrations` items with strict `superstruct` `object()` schemas, which reject unknown keys. Verified locally — `create()` throws `at path: custom_integrations.0 -- Expected the value to satisfy a union of \`object | object\`, but received: ...`. The post handler converts that into a `400` and the install's analytics submission is dropped. So if Core starts sending `issue_tracker` to a worker that doesn't accept it, every install on the new Core silently loses analytics until this PR is live.

Once deployed, this PR is forward- and backward-compatible: `issue_tracker` is `optional(nullable(string()))`, so old Core (no field), new Core with no manifest tracker (`null`), and new Core with a tracker (`string`) all pass.

## Aggregation model

Mirrors the existing `versions` pattern: each domain gets a counter map of distinct issue_tracker URLs. This preserves forks/disagreements and lets downstream consumers pick the most-reported tracker.

`custom_integrations.json` per-domain shape:

```json
{
  "alexa_media": {
    "total": 18430,
    "versions": {
      "4.13.1": 17800,
      "4.12.0": 630
    },
    "issue_trackers": {
      "https://github.com/alandtse/alexa_media_player/issues": 18420,
      "https://github.com/fork/alexa_media/issues": 10
    }
  }
}
```

New Prometheus metric — one line per (domain, tracker URL) pair, count = installs reporting that pair:

```
custom_integration{domain="alexa_media"} 18430
custom_integration_version{domain="alexa_media",version="4.13.1"} 17800
custom_integration_version{domain="alexa_media",version="4.12.0"} 630
custom_integration_issue_tracker{domain="alexa_media",issue_tracker="https://github.com/alandtse/alexa_media_player/issues"} 18420
custom_integration_issue_tracker{domain="alexa_media",issue_tracker="https://github.com/fork/alexa_media/issues"} 10
```

For domains where no install reports a tracker, `issue_trackers` is `{}` and **no** `custom_integration_issue_tracker` line is emitted, keeping cardinality bounded.

## Other notes

`SCHEMA_VERSION_QUEUE` bumped 15 → 16. Necessary because `QueueData.custom_integrations[*]` gained an `issue_trackers` field; without the bump, an in-flight queue persisted in KV from before this deploy would resume on the new code path and crash on `data.custom_integrations[domain].issue_trackers[url] = …` (set on undefined). The bump triggers a clean reset on the first PROCESS_QUEUE tick after deploy.

## Test plan

- [x] `yarn jest` — 35/35 passing (4 new tests):
  - validate.spec: `issue_tracker` omitted, `null`, and wrong-type rejection
  - schedule.spec: aggregation across installs reporting upstream tracker / fork tracker / no tracker for the same domain
- [x] Manual `wrangler dev -e local-dev`: real POSTs with `issue_tracker` set/unset/null/wrong-type all behave as expected (200/200/200/400)
- [x] Manual eleventy build against an injected fixture: new metric lines render in `/prometheus/custom_integrations`, JSON dataset includes `issue_trackers` per domain