### PR TITLE
feat: remove brands domain gate for custom integrations

### DIFF
--- a/worker/src/data.ts
+++ b/worker/src/data.ts
@@ -9,8 +9,6 @@ export const KV_MAX_PROCESS_ENTRIES = 800;
 export const SCHEMA_VERSION_QUEUE = 15;
 export const SCHEMA_VERSION_ANALYTICS = 4;
 
-export const BRANDS_DOMAINS_URL =
-  "https://brands.home-assistant.io/domains.json";
 export const VERSION_URL = "https://version.home-assistant.io/dev.json";
 
 export interface WorkerEnv {

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -22,7 +22,6 @@ import {
   generateUuidMetadata,
   KV_KEY_ADDONS,
   KV_KEY_CUSTOM_INTEGRATIONS,
-  BRANDS_DOMAINS_URL,
   VERSION_URL,
   VersionResponse,
   ScheduledWorkerEvent,
@@ -236,33 +235,17 @@ async function processQueue(
   }
 
   sentry.addBreadcrumb({
-    message: "Fetching external data from brands and version",
+    message: "Fetching external data from version",
   });
-  const [brandsDomainsResponse, versionResponse] = await Promise.all([
-    fetch(BRANDS_DOMAINS_URL),
-    fetch(VERSION_URL),
-  ]);
+  const versionResponse = await fetch(VERSION_URL);
 
-  sentry.setExtra("brandsDomainsResponse", brandsDomainsResponse);
   sentry.setExtra("versionResponse", versionResponse);
 
-  if (!brandsDomainsResponse.ok) {
-    throw Error("Could not get domain list from brands");
-  }
   if (!versionResponse.ok) {
-    throw Error("Could not get domain list from brands");
+    throw Error("Could not get version data");
   }
-
-  const brandsDomainsJson: {
-    core: string[];
-    custom: string[];
-  } = await brandsDomainsResponse.json();
 
   const osBoardsJson = await versionResponse.json<VersionResponse>();
-
-  const brandsDomains: Set<string> = new Set(
-    brandsDomainsJson.custom.concat(brandsDomainsJson.core)
-  );
 
   const osBoards: Set<string> = new Set(Object.keys(osBoardsJson.hassos));
 
@@ -271,12 +254,7 @@ async function processQueue(
     entryData = await event.env.KV.get<IncomingPayload>(entryKey, "json");
 
     if (entryData !== undefined && entryData !== null) {
-      queue.data = combineEntryData(
-        queue.data,
-        entryData,
-        brandsDomains,
-        osBoards
-      );
+      queue.data = combineEntryData(queue.data, entryData, osBoards);
     }
   }
 
@@ -397,7 +375,6 @@ function combineMetadataEntryData(
 function combineEntryData(
   data: QueueData,
   entrydata: IncomingPayload,
-  brandsDomains: Set<string>,
   osBoards: Set<string>
 ): QueueData {
   const reported_integrations = entrydata.integrations || [];
@@ -523,10 +500,6 @@ function combineEntryData(
 
   if (reported_custom_integrations.length) {
     for (const custom_integration of reported_custom_integrations) {
-      if (!brandsDomains.has(custom_integration.domain)) {
-        continue;
-      }
-
       if (!data.custom_integrations[custom_integration.domain]) {
         data.custom_integrations[custom_integration.domain] = {
           total: 0,

--- a/worker/tests/handlers/schedule.spec.ts
+++ b/worker/tests/handlers/schedule.spec.ts
@@ -312,13 +312,13 @@ describe("schedule handler", function () {
       );
       expect(event.env.KV.put).toBeCalledWith(
         KV_KEY_CUSTOM_INTEGRATIONS,
-        '{"custom_valid":{"total":500,"versions":{"1.2.3":500}}}'
+        '{"custom_invalid":{"total":500,"versions":{"1.2.3":500}},"custom_valid":{"total":500,"versions":{"1.2.3":500}}}'
       );
       expect(event.env.KV.put).toBeCalledWith(
         expect.stringContaining("history:"),
         expect.any(String)
       );
-      expect(MockFetch).toBeCalledTimes(3);
+      expect(MockFetch).toBeCalledTimes(2);
       expect(event.env.KV.put).toBeCalledTimes(5);
     });
 


### PR DESCRIPTION
## Summary

- Drops the `brands.home-assistant.io/domains.json` fetch and the `brandsDomains.has(custom_integration.domain)` check that previously filtered reported custom integrations down to the curated brands list.
- All reported custom integration domains now flow through to the aggregated analytics. The `brandsDomains` Set, the parallel fetch, and the `BRANDS_DOMAINS_URL` constant are removed as dead code.
- Test updated to reflect the new behaviour: `custom_invalid` is no longer dropped from the aggregated output, and the brands fetch is no longer counted.

## Relationship to #1089

This PR is related to #1089 (`feat: accept custom integration issue_tracker`). That PR adds `issue_tracker` aggregation but, with the brands gate still in place, the new field is only captured for the small subset of custom integrations registered in the brands repository — which are typically the ones whose issue tracker is already known. Removing the gate is what makes the `issue_tracker` telemetry actually useful for the long tail of unregistered custom integrations (HACS and similar).

## Potential concern: filtering is now gone

The brands allowlist was the implicit filter against arbitrary client-reported integrations. Without it, anyone sending payloads to the analytics endpoint can introduce sketchy or nonexistant integrations into the public dataset and into the Prometheus metrics. Worth thinking about whether we want any replacement guardrail.