### PR TITLE
Increase queue processing rate

### DIFF
--- a/worker/src/data.ts
+++ b/worker/src/data.ts
@@ -4,7 +4,7 @@ export const KV_KEY_CUSTOM_INTEGRATIONS = "custom_integrations";
 export const KV_KEY_ADDONS = "addons";
 export const KV_PREFIX_HISTORY = "history";
 export const KV_PREFIX_UUID = "uuid";
-export const KV_MAX_PROCESS_ENTRIES = 950;
+export const KV_MAX_PROCESS_ENTRIES = 800;
 
 export const SCHEMA_VERSION_QUEUE = 15;
 export const SCHEMA_VERSION_ANALYTICS = 4;

--- a/worker/src/data.ts
+++ b/worker/src/data.ts
@@ -4,7 +4,7 @@ export const KV_KEY_CUSTOM_INTEGRATIONS = "custom_integrations";
 export const KV_KEY_ADDONS = "addons";
 export const KV_PREFIX_HISTORY = "history";
 export const KV_PREFIX_UUID = "uuid";
-export const KV_MAX_PROCESS_ENTRIES = 800;
+export const KV_MAX_PROCESS_ENTRIES = 950;
 
 export const SCHEMA_VERSION_QUEUE = 15;
 export const SCHEMA_VERSION_ANALYTICS = 4;
@@ -59,7 +59,7 @@ export enum MetadataExtra {
 }
 
 export enum ScheduledTask {
-  PROCESS_QUEUE = "*/2 * * * *",
+  PROCESS_QUEUE = "*/1 * * * *",
   RESET_QUEUE = "5 0 * * *",
   UPDATE_HISTORY = "0 * * * *",
   REGENERATE_SITE = "15 * * * *",

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -40,7 +40,7 @@ export async function handleSchedule(
   try {
     switch (scheduledTask) {
       case ScheduledTask.PROCESS_QUEUE:
-        // Runs every 2 minutes
+        // Runs every minute
         await processQueue(event, sentry);
         break;
       case ScheduledTask.RESET_QUEUE:

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -4,7 +4,7 @@ main = "./src/index.ts"
 send_metrics = false
 
 [triggers]
-crons = ["*/2 * * * *", "5 0 * * *", "0 * * * *", "15 * * * *"]
+crons = ["*/1 * * * *", "5 0 * * *", "0 * * * *", "15 * * * *"]
 
 # For production environment, use '-e production'
 [env.production]


### PR DESCRIPTION
## Summary

- Run the `PROCESS_QUEUE` scheduled task every minute instead of every 2 minutes

With the current submission rate it takes 22 hours to process the whole queue. Doubling the processing frequency roughly halves that.

## Limits

Reference: [Cloudflare Workers limits](https://developers.cloudflare.com/workers/platform/limits/)

The relevant cap is the 1,000 KV operations per Worker invocation. Each cron trigger runs as its own invocation, so the per-run cost is unchanged: a `PROCESS_QUEUE` run does ~802 KV operations (1 queue get + 800 entry gets + 1 queue put), staying well under the limit.

`KV_MAX_PROCESS_ENTRIES` was initially bumped to 950 here but rolled back to 800: the missing-metadata recovery path in `UPDATE_HISTORY` repairs up to `KV_MAX_PROCESS_ENTRIES / 2` entries at 2 KV operations each, on top of the full UUID list pagination. It's unclear how close that path already is to the 1,000-operation limit with the current install base, so the value stays at 800 rather than risking it.