### PR TITLE
Track custom integrations from the HACS default list

### DIFF
--- a/worker/src/data.ts
+++ b/worker/src/data.ts
@@ -2,15 +2,22 @@ export const KV_KEY_QUEUE = "queue";
 export const KV_KEY_CORE_ANALYTICS = "core_analytics";
 export const KV_KEY_CUSTOM_INTEGRATIONS = "custom_integrations";
 export const KV_KEY_ADDONS = "addons";
+export const KV_KEY_HACS_DOMAINS = "hacs_domains";
 export const KV_PREFIX_HISTORY = "history";
 export const KV_PREFIX_UUID = "uuid";
 export const KV_MAX_PROCESS_ENTRIES = 800;
+
+// The HACS default repository list changes a few times a day, and this runs
+// every minute, so it is refreshed at most daily and cached in KV.
+export const HACS_DOMAINS_MAX_AGE = 86_400_000;
 
 export const SCHEMA_VERSION_QUEUE = 15;
 export const SCHEMA_VERSION_ANALYTICS = 4;
 
 export const BRANDS_DOMAINS_URL =
   "https://brands.home-assistant.io/domains.json";
+export const HACS_INTEGRATIONS_URL =
+  "https://data-v2.hacs.xyz/integration/data.json";
 export const VERSION_URL = "https://version.home-assistant.io/dev.json";
 
 export interface WorkerEnv {
@@ -78,6 +85,20 @@ export interface UuidMetadata {
 export interface VersionResponse {
   channel: string;
   hassos: Record<string, string>;
+}
+
+export interface BrandsDomainsResponse {
+  core: string[];
+  custom: string[];
+}
+
+export interface HacsIntegrationsResponse {
+  [repository_id: string]: { domain?: string | null };
+}
+
+export interface CachedHacsDomains {
+  last_updated: number;
+  domains: string[];
 }
 
 export interface CfRequest extends Request {

--- a/worker/src/handlers/schedule.ts
+++ b/worker/src/handlers/schedule.ts
@@ -22,11 +22,18 @@ import {
   generateUuidMetadata,
   KV_KEY_ADDONS,
   KV_KEY_CUSTOM_INTEGRATIONS,
+  KV_KEY_HACS_DOMAINS,
   BRANDS_DOMAINS_URL,
+  BrandsDomainsResponse,
+  CachedHacsDomains,
+  HACS_DOMAINS_MAX_AGE,
+  HACS_INTEGRATIONS_URL,
+  HacsIntegrationsResponse,
   VERSION_URL,
   VersionResponse,
   ScheduledWorkerEvent,
 } from "../data";
+import { fetchJson } from "../utils/fetch-json";
 import { groupVersions } from "../utils/group-versions";
 import { median } from "../utils/median";
 import { migrateAnalyticsData } from "../utils/migrate";
@@ -236,35 +243,9 @@ async function processQueue(
   }
 
   sentry.addBreadcrumb({
-    message: "Fetching external data from brands and version",
+    message: "Fetching external data from brands, HACS and version",
   });
-  const [brandsDomainsResponse, versionResponse] = await Promise.all([
-    fetch(BRANDS_DOMAINS_URL),
-    fetch(VERSION_URL),
-  ]);
-
-  sentry.setExtra("brandsDomainsResponse", brandsDomainsResponse);
-  sentry.setExtra("versionResponse", versionResponse);
-
-  if (!brandsDomainsResponse.ok) {
-    throw Error("Could not get domain list from brands");
-  }
-  if (!versionResponse.ok) {
-    throw Error("Could not get domain list from brands");
-  }
-
-  const brandsDomainsJson: {
-    core: string[];
-    custom: string[];
-  } = await brandsDomainsResponse.json();
-
-  const osBoardsJson = await versionResponse.json<VersionResponse>();
-
-  const brandsDomains: Set<string> = new Set(
-    brandsDomainsJson.custom.concat(brandsDomainsJson.core)
-  );
-
-  const osBoards: Set<string> = new Set(Object.keys(osBoardsJson.hassos));
+  const { knownDomains, osBoards } = await fetchExternalData(event, sentry);
 
   async function handleEntry(entryKey: string) {
     let entryData;
@@ -274,7 +255,7 @@ async function processQueue(
       queue.data = combineEntryData(
         queue.data,
         entryData,
-        brandsDomains,
+        knownDomains,
         osBoards
       );
     }
@@ -331,6 +312,89 @@ async function processQueue(
   }
   sentry.addBreadcrumb({ message: "Process complete" });
   await event.env.KV.put(KV_KEY_QUEUE, JSON.stringify(queue));
+}
+
+// The documents backing these sets are large compared to what we keep from
+// them, so they are parsed and reduced here, out of the scope that stays alive
+// while the queue entries are processed.
+async function fetchExternalData(
+  event: ScheduledWorkerEvent,
+  sentry: Toucan
+): Promise<{
+  knownDomains: Set<string>;
+  osBoards: Set<string>;
+}> {
+  const [brandsDomainsJson, hacsDomains, osBoardsJson] = await Promise.all([
+    fetchJson<BrandsDomainsResponse>(sentry, BRANDS_DOMAINS_URL, {
+      sentryExtra: "brandsDomainsResponse",
+      errorMessage: "Could not get domain list from brands",
+    }),
+    getHacsDomains(event, sentry),
+    fetchJson<VersionResponse>(sentry, VERSION_URL, {
+      sentryExtra: "versionResponse",
+      errorMessage: "Could not get board list from version",
+    }),
+  ]);
+
+  // Reported custom integrations are only counted when we know the domain.
+  // brands no longer accepts new custom_integrations entries (HA 2026.3.0), so
+  // the HACS default repositories are used as an additional source of domains.
+  const knownDomains: Set<string> = new Set(
+    brandsDomainsJson.custom.concat(brandsDomainsJson.core)
+  );
+
+  for (const domain of hacsDomains) {
+    knownDomains.add(domain);
+  }
+
+  return {
+    knownDomains,
+    osBoards: new Set(Object.keys(osBoardsJson.hassos)),
+  };
+}
+
+// The domains of the HACS default repositories, refreshed at most once a day.
+// HACS is not ours and it only widens the set of domains we recognise, so a
+// failure to refresh falls back to the cached list rather than failing the run.
+async function getHacsDomains(
+  event: ScheduledWorkerEvent,
+  sentry: Toucan
+): Promise<string[]> {
+  const cached = await event.env.KV.get<CachedHacsDomains>(
+    KV_KEY_HACS_DOMAINS,
+    "json"
+  );
+  const timestamp = new Date().getTime();
+
+  if (cached && timestamp - cached.last_updated < HACS_DOMAINS_MAX_AGE) {
+    return cached.domains;
+  }
+
+  try {
+    const hacsIntegrationsJson = await fetchJson<HacsIntegrationsResponse>(
+      sentry,
+      HACS_INTEGRATIONS_URL,
+      {
+        sentryExtra: "hacsIntegrationsResponse",
+        errorMessage: "Could not get integration list from HACS",
+      }
+    );
+
+    const domains = Object.values(hacsIntegrationsJson)
+      .map((repository) => repository.domain)
+      .filter((domain): domain is string => !!domain);
+
+    await event.env.KV.put(
+      KV_KEY_HACS_DOMAINS,
+      JSON.stringify({ last_updated: timestamp, domains })
+    );
+
+    return domains;
+  } catch (e: any) {
+    const fallback = cached ? "the cached list" : "brands only";
+    sentry.captureMessage(`${e?.message} (using ${fallback})`, "warning");
+    return cached?.domains || [];
+  }
 }
 
 async function listKV(
@@ -397,7 +461,7 @@ function combineMetadataEntryData(
 function combineEntryData(
   data: QueueData,
   entrydata: IncomingPayload,
-  brandsDomains: Set<string>,
+  knownDomains: Set<string>,
   osBoards: Set<string>
 ): QueueData {
   const reported_integrations = entrydata.integrations || [];
@@ -523,7 +587,7 @@ function combineEntryData(
 
   if (reported_custom_integrations.length) {
     for (const custom_integration of reported_custom_integrations) {
-      if (!brandsDomains.has(custom_integration.domain)) {
+      if (!knownDomains.has(custom_integration.domain)) {
         continue;
       }
 

--- a/worker/src/utils/fetch-json.ts
+++ b/worker/src/utils/fetch-json.ts
@@ -1,0 +1,23 @@
+import { Toucan } from "toucan-js";
+
+// Fetch a JSON document from one of the external sources we depend on.
+// Keeps the URL, the Sentry extra and the error message for a source together,
+// instead of spreading them over separate fetch/check/parse blocks.
+export const fetchJson = async <T>(
+  sentry: Toucan,
+  url: string,
+  options: {
+    sentryExtra: string;
+    errorMessage: string;
+  }
+): Promise<T> => {
+  const response = await fetch(url);
+
+  sentry.setExtra(options.sentryExtra, response);
+
+  if (!response.ok) {
+    throw Error(options.errorMessage);
+  }
+
+  return response.json<T>();
+};

--- a/worker/tests/handlers/schedule.spec.ts
+++ b/worker/tests/handlers/schedule.spec.ts
@@ -1,9 +1,12 @@
 import {
   createQueueData,
   createQueueDefaults,
+  HACS_DOMAINS_MAX_AGE,
+  HACS_INTEGRATIONS_URL,
   KV_KEY_ADDONS,
   KV_KEY_CORE_ANALYTICS,
   KV_KEY_CUSTOM_INTEGRATIONS,
+  KV_KEY_HACS_DOMAINS,
   KV_KEY_QUEUE,
   ScheduledTask,
   SCHEMA_VERSION_ANALYTICS,
@@ -19,13 +22,20 @@ describe("schedule handler", function () {
   beforeEach(() => {
     MockSentry = MockedSentry();
     (global as any).console = MockedConsole();
-    (global as any).fetch = MockFetch = jest.fn(async () => ({
+    (global as any).fetch = MockFetch = jest.fn(async (url: string) => ({
       ok: true,
-      json: jest.fn(async () => ({
-        core: ["core_valid"],
-        custom: ["custom_valid"],
-        hassos: { rpi: "" },
-      })),
+      json: jest.fn(async () =>
+        url === HACS_INTEGRATIONS_URL
+          ? {
+              "1234": { domain: "hacs_valid" },
+              "5678": { domain: null },
+            }
+          : {
+              core: ["core_valid"],
+              custom: ["custom_valid"],
+              hassos: { rpi: "" },
+            }
+      ),
     }));
     (global as any).NETLIFY_BUILD_HOOK = "";
     (global as any).WORKER_ENV = "production";
@@ -214,7 +224,12 @@ describe("schedule handler", function () {
       );
 
       expect(event.env.KV.put).toBeCalledWith(KV_KEY_QUEUE, expect.any(String));
-      expect(event.env.KV.put).toBeCalledTimes(1);
+      // The queue, plus the refreshed HACS domain cache.
+      expect(event.env.KV.put).toBeCalledWith(
+        KV_KEY_HACS_DOMAINS,
+        expect.any(String)
+      );
+      expect(event.env.KV.put).toBeCalledTimes(2);
     });
 
     it("Continue queue - 2000 entries left", async () => {
@@ -251,7 +266,12 @@ describe("schedule handler", function () {
         KV_KEY_QUEUE,
         expect.stringContaining('"process_complete":false')
       );
-      expect(event.env.KV.put).toBeCalledTimes(1);
+      // The queue, plus the refreshed HACS domain cache.
+      expect(event.env.KV.put).toBeCalledWith(
+        KV_KEY_HACS_DOMAINS,
+        expect.any(String)
+      );
+      expect(event.env.KV.put).toBeCalledTimes(2);
     });
 
     it("Continue queue - 500 entries left", async () => {
@@ -270,12 +290,16 @@ describe("schedule handler", function () {
               data: createQueueData(),
             };
           }
+          if (key === KV_KEY_HACS_DOMAINS) {
+            return null;
+          }
 
           return {
             integrations: ["core_valid"],
             custom_integrations: [
               { domain: "custom_invalid", version: "1.2.3" },
               { domain: "custom_valid", version: "1.2.3" },
+              { domain: "hacs_valid", version: "1.2.3" },
             ],
             operating_system: {
               board: "invalid_board",
@@ -312,14 +336,131 @@ describe("schedule handler", function () {
       );
       expect(event.env.KV.put).toBeCalledWith(
         KV_KEY_CUSTOM_INTEGRATIONS,
-        '{"custom_valid":{"total":500,"versions":{"1.2.3":500}}}'
+        '{"custom_valid":{"total":500,"versions":{"1.2.3":500}},' +
+          '"hacs_valid":{"total":500,"versions":{"1.2.3":500}}}'
       );
       expect(event.env.KV.put).toBeCalledWith(
         expect.stringContaining("history:"),
         expect.any(String)
       );
-      expect(MockFetch).toBeCalledTimes(3);
-      expect(event.env.KV.put).toBeCalledTimes(5);
+      expect(event.env.KV.put).toBeCalledWith(
+        KV_KEY_HACS_DOMAINS,
+        expect.stringContaining('"domains":["hacs_valid"]')
+      );
+      expect(MockFetch).toBeCalledTimes(4);
+      expect(event.env.KV.put).toBeCalledTimes(6);
+    });
+
+    // The HACS domain list is refreshed at most once a day and cached in KV,
+    // so these cover the cache being fresh, and HACS being unreachable with
+    // and without something cached to fall back on.
+    const hacsCacheEvent = (hacsCache: any) => {
+      const event = MockedScheduledEvent({
+        controller: { cron: ScheduledTask.PROCESS_QUEUE },
+      });
+      (event.env.KV.get as jest.Mock).mockImplementation(
+        async (key: string) => {
+          if (key === KV_KEY_QUEUE) {
+            return {
+              schema_version: SCHEMA_VERSION_QUEUE,
+              process_complete: false,
+              entries: [{ name: "uuid:1" }],
+              data: createQueueData(),
+            };
+          }
+          if (key === KV_KEY_HACS_DOMAINS) {
+            return hacsCache;
+          }
+
+          return {
+            custom_integrations: [
+              { domain: "custom_valid", version: "1.2.3" },
+              { domain: "hacs_valid", version: "1.2.3" },
+            ],
+          };
+        }
+      );
+      return event;
+    };
+
+    const bothCounted =
+      '{"custom_valid":{"total":1,"versions":{"1.2.3":1}},' +
+      '"hacs_valid":{"total":1,"versions":{"1.2.3":1}}}';
+
+    it("Cached HACS domains are still fresh - no refetch", async () => {
+      const event = hacsCacheEvent({
+        last_updated: new Date().getTime(),
+        domains: ["hacs_valid"],
+      });
+
+      await handleSchedule(event, MockSentry);
+
+      expect(MockFetch).not.toBeCalledWith(HACS_INTEGRATIONS_URL);
+      expect(event.env.KV.put).not.toBeCalledWith(
+        KV_KEY_HACS_DOMAINS,
+        expect.any(String)
+      );
+      expect(event.env.KV.put).toBeCalledWith(
+        KV_KEY_CUSTOM_INTEGRATIONS,
+        bothCounted
+      );
+    });
+
+    it("Cached HACS domains are stale and HACS is down - use the cache", async () => {
+      const event = hacsCacheEvent({
+        last_updated: new Date().getTime() - HACS_DOMAINS_MAX_AGE - 1,
+        domains: ["hacs_valid"],
+      });
+      (global as any).fetch = MockFetch = jest.fn(async (url: string) => ({
+        ok: url !== HACS_INTEGRATIONS_URL,
+        json: jest.fn(async () => ({
+          core: ["core_valid"],
+          custom: ["custom_valid"],
+          hassos: { rpi: "" },
+        })),
+      }));
+
+      await handleSchedule(event, MockSentry);
+
+      expect(MockFetch).toBeCalledWith(HACS_INTEGRATIONS_URL);
+      expect(MockSentry.captureException).not.toBeCalled();
+      expect(MockSentry.captureMessage).toBeCalledWith(
+        "Could not get integration list from HACS (using the cached list)",
+        "warning"
+      );
+      // The stale cache is kept rather than overwritten with a worse one.
+      expect(event.env.KV.put).not.toBeCalledWith(
+        KV_KEY_HACS_DOMAINS,
+        expect.any(String)
+      );
+      expect(event.env.KV.put).toBeCalledWith(
+        KV_KEY_CUSTOM_INTEGRATIONS,
+        bothCounted
+      );
+    });
+
+    it("HACS is down with nothing cached - keep processing on brands", async () => {
+      const event = hacsCacheEvent(null);
+      (global as any).fetch = MockFetch = jest.fn(async (url: string) => ({
+        ok: url !== HACS_INTEGRATIONS_URL,
+        json: jest.fn(async () => ({
+          core: ["core_valid"],
+          custom: ["custom_valid"],
+          hassos: { rpi: "" },
+        })),
+      }));
+
+      await handleSchedule(event, MockSentry);
+
+      expect(MockSentry.captureException).not.toBeCalled();
+      expect(MockSentry.captureMessage).toBeCalledWith(
+        "Could not get integration list from HACS (using brands only)",
+        "warning"
+      );
+      expect(event.env.KV.put).toBeCalledWith(
+        KV_KEY_CUSTOM_INTEGRATIONS,
+        '{"custom_valid":{"total":1,"versions":{"1.2.3":1}}}'
+      );
     });
 
     it("Wait for reset", async () => {


### PR DESCRIPTION
## Proposed change

`processQueue` only counts a reported custom integration if its domain is in [brands' `domains.json`](https://brands.home-assistant.io/domains.json), and since HA 2026.3.0 brands no longer accepts new `custom_integrations/` entries ([Brands Proxy API announcement](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api)). A custom integration created after the freeze can therefore never appear in the public stats, however many installations report it.

This adds the HACS default repository list as a second source of known domains — **901 domains that brands does not have** today — and keeps working for anything added to HACS from now on.

The list comes from `https://data-v2.hacs.xyz/integration/data.json` (the same host HACS itself uses), is reduced to a plain list of domains, and is cached in KV. It refreshes at most once a day; a failed refresh reuses the cached list and raises a Sentry warning, so an outage of a third-party source can't stall queue processing. With nothing cached it falls back to brands alone.

Matching against a curated list rather than accepting any reported domain keeps the property the brands filter was there for: only domains from a publicly reviewable list are counted, so `custom_integrations.json` can't be filled with arbitrary keys.

### Notes for reviewers

- `worker/src/utils/fetch-json.ts` is new — three sources now share the fetch/check/parse shape, so it is extracted. That also surfaced the `!versionResponse.ok` branch throwing `"Could not get domain list from brands"`, now corrected.
- This does not help integrations distributed outside the HACS default list, including the one in #1094. It fixes the large, tractable slice; anything further needs a decision on what the source of truth should be post-freeze.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes issue #1094

## Checklist

- [x] The code change is tested and works locally (`script/worker_test`, `script/worker_build`).
- [x] There is no commented out code in this PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
